### PR TITLE
Siphon Readiness from MetalLB Script

### DIFF
--- a/pkg/util/provisioner/interfaces.go
+++ b/pkg/util/provisioner/interfaces.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2022 EscherCloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provisioner
+
+// Provisioner is an abstract type that allows provisioning of Kubernetes
+// packages in a technology agnostic way.  For example some things may be
+// installed as a raw set of resources, a YAML manifest, Helm etc.
+type Provisioner interface {
+	// Provision deploys the requested package.
+	// Implementations should ensure this receiver is idempotent.
+	Provision() error
+}
+
+// ReadinessCheck is an abstract way of reasoning about the readiness of
+// a component installed by a provisioner.  It's a way of providing a
+// barrier essentially, as one thing may depend on another being deployed
+// in order to function correctly.
+type ReadinessCheck interface {
+	// Check performs a single iteration of a readiness check.
+	// Retries are delegated to the caller.
+	Check() error
+}

--- a/pkg/util/provisioner/readiness_daemonset.go
+++ b/pkg/util/provisioner/readiness_daemonset.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2022 EscherCloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provisioner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+)
+
+var (
+	ErrDaemonsetUnready = errors.New("daemonset readiness doesn't match desired")
+)
+
+type DaemonsetReady struct {
+	// client is an intialized Kubernetes client.
+	client kubernetes.Interface
+
+	// namespace is the namespace a resource resides in.
+	namespace string
+
+	// name is the name of the resource.
+	name string
+}
+
+// Ensure the ReadinessCheck interface is implmented.
+var _ ReadinessCheck = &DaemonsetReady{}
+
+// NewDaemonsetReady creates a new daemonset readiness check.
+func NewDaemonsetReady(client kubernetes.Interface, namespace, name string) ReadinessCheck {
+	return &DaemonsetReady{
+		client:    client,
+		namespace: namespace,
+		name:      name,
+	}
+}
+
+// Check implements the ReadinessCheck interface.
+func (r *DaemonsetReady) Check() error {
+	daemonset, err := r.client.AppsV1().DaemonSets(r.namespace).Get(context.TODO(), r.name, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("daemonset get error: %w", err)
+	}
+
+	if daemonset.Status.NumberReady != daemonset.Status.DesiredNumberScheduled {
+		return fmt.Errorf("%w: status mismatch", ErrDaemonsetUnready)
+	}
+
+	return nil
+
+}

--- a/pkg/util/provisioner/readiness_status_condition.go
+++ b/pkg/util/provisioner/readiness_status_condition.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2022 EscherCloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provisioner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+)
+
+var (
+	// ErrConditionFormat means the formatting of the condition is wrong,
+	// these are loosly defined, but there are some conventions.
+	ErrConditionFormat = errors.New("status condition incorrectly formatted")
+
+	// ErrConditionMissing means the condition isn't present.
+	ErrConditionMissing = errors.New("status condition not found")
+
+	// ErrConditionStatus means the condition has the wrong truthiness.
+	ErrConditionStatus = errors.New("status condition incorrect status")
+)
+
+// StatusConditionReady allows any Kubernetes resource to be polled for
+// a status condition that is true.  For example Deployments are ready
+// when the Available status condition is set.
+// TODO: we could provide a nicer interface that accepts a concrete type
+// via runtime.Object and runs it through the REST mapper to derive the
+// GVR.
+// TODO: this only considers namespaced resources, ties into REST mapping
+// also.
+type StatusConditionReady struct {
+	// client is an intialized Kubernetes dynamic client.
+	client dynamic.Interface
+
+	// gvr describes the resource type and API paths.
+	gvr schema.GroupVersionResource
+
+	// namespace is the namespace a resource resides in.
+	namespace string
+
+	// name is the name of the resource.
+	name string
+
+	// conditionType is the type of condition to look for.
+	conditionType string
+}
+
+// Ensure the ReadinessCheck interface is implmented.
+var _ ReadinessCheck = &StatusConditionReady{}
+
+// NewStatusConditionReady creates a new status condition readiness check.
+func NewStatusConditionReady(client dynamic.Interface, gvr schema.GroupVersionResource, namespace, name, conditionType string) ReadinessCheck {
+	return &StatusConditionReady{
+		client:        client,
+		gvr:           gvr,
+		namespace:     namespace,
+		name:          name,
+		conditionType: conditionType,
+	}
+}
+
+// Check implements the ReadinessCheck interface.
+func (r *StatusConditionReady) Check() error {
+	object, err := r.client.Resource(r.gvr).Namespace(r.namespace).Get(context.TODO(), r.name, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	conditions, _, err := unstructured.NestedSlice(object.Object, "status", "conditions")
+	if err != nil {
+		return fmt.Errorf("%w: conditions lookup error: %s", ErrConditionFormat, err.Error())
+	}
+
+	for i := range conditions {
+		condition, ok := conditions[i].(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("%w: condition type assertion error:", ErrConditionFormat)
+		}
+
+		t, _, err := unstructured.NestedString(condition, "type")
+		if err != nil {
+			return fmt.Errorf("%w: condition type error: %s", ErrConditionFormat, err.Error())
+		}
+
+		if t != r.conditionType {
+			continue
+		}
+
+		s, _, err := unstructured.NestedString(condition, "status")
+		if err != nil {
+			return fmt.Errorf("%w: condition status error: %s", ErrConditionFormat, err.Error())
+		}
+
+		if s != "True" {
+			return ErrConditionStatus
+		}
+
+		return nil
+	}
+
+	return ErrConditionMissing
+}

--- a/pkg/util/retry/retry.go
+++ b/pkg/util/retry/retry.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2022 EscherCloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package retry
+
+import (
+	"context"
+	"time"
+)
+
+// RetryFunc is a callback that must return nil to escape the retry loop.
+type RetryFunc func() error
+
+// Retrier implements retry loop logic.
+type Retrier struct {
+	// context is used to terminate the retry loop on either a timeout
+	// or a cancellation call from another routine.  See WithContext()
+	// and WithTimeout for additional behaviour.  If not set it will
+	// retry forever.
+	context context.Context
+
+	// cancel is associated with a context to free resources.
+	cancel func()
+
+	// period defines the default retry period, defaulting to 1 second.
+	period time.Duration
+}
+
+// Froever returns a retrier that will retry soething forever until a nil error
+// is returned.
+func Forever() *Retrier {
+	return &Retrier{
+		context: context.TODO(),
+		period:  time.Second,
+	}
+}
+
+// WithContext allows a global context to be registered with this retry function,
+// e.g. if a timeout spans the whole transaction, and not just this single retry.
+func WithContext(c context.Context) *Retrier {
+	return &Retrier{
+		context: c,
+		period:  time.Second,
+	}
+}
+
+// WithTimeout returns a retrier that will execute for a specifc length of time.
+func WithTimeout(timeout time.Duration) *Retrier {
+	c, cancel := context.WithTimeout(context.TODO(), timeout)
+
+	return &Retrier{
+		context: c,
+		cancel:  cancel,
+		period:  time.Second,
+	}
+}
+
+// WithPeriod defines how often to perform the retry.
+func (r *Retrier) WithPeriod(period time.Duration) *Retrier {
+	r.period = period
+	return r
+}
+
+// WithTimeout wraps the existing context with a timeout specific to this retry
+// invocation.  This should only be used with WithContext(ctx).WithTimeout() to
+// augment a global timeout with a local one as this call does not respect existing
+// cancel functions.
+func (r *Retrier) WithTimeout(timeout time.Duration) *Retrier {
+	r.context, r.cancel = context.WithTimeout(r.context, timeout)
+	return r
+}
+
+// Do starts the retry loop.  It will run until a context times out or is cancelled,
+// or the retry function returns nil indicating success.
+func (r *Retrier) Do(f RetryFunc) error {
+	if r.cancel != nil {
+		defer r.cancel()
+	}
+
+	t := time.NewTicker(r.period)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-r.context.Done():
+			return r.context.Err()
+		case <-t.C:
+			if err := f(); err != nil {
+				break
+			}
+
+			return nil
+		}
+	}
+}


### PR DESCRIPTION
Condition based readiness checks and even the type specific daemonset based ones are pretty generic and should be shared as they will inevitably come in useful for Unikorn proper.  So I've come up with a couple interfaces, one for readiness checks, and another for provisioners.