### PR TITLE
Add in Control Plane Getter

### DIFF
--- a/pkg/cmd/get/get_control_plane.go
+++ b/pkg/cmd/get/get_control_plane.go
@@ -22,90 +22,79 @@ import (
 	"os"
 	"strings"
 
+	"github.com/eschercloudai/unikorn/generated/clientset/unikorn"
+	unikornv1alpha1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
 	"github.com/eschercloudai/unikorn/pkg/cmd/errors"
 	"github.com/eschercloudai/unikorn/pkg/cmd/util"
-	"github.com/eschercloudai/unikorn/pkg/constants"
 
 	"github.com/spf13/cobra"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/kubectl/pkg/cmd/get"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/util/completion"
 )
 
-// getControlPlaneNamespace gets a single control plane namespace.
-// TODO: utility function.
-func getControlPlaneNamespace(client kubernetes.Interface, name string) (*corev1.Namespace, error) {
-	ns, err := client.CoreV1().Namespaces().Get(context.TODO(), name, metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-
-	if _, ok := ns.Labels[constants.ControlPlaneLabel]; !ok {
-		return nil, fmt.Errorf("%w: %s", errors.ErrNotFound, name)
-	}
-
-	// TODO: this is caused by doing a typed read/decode, if we do this unstructured
-	// using a dynamic client we'll have a happier time.
-	ns.TypeMeta.APIVersion = "v1"
-	ns.TypeMeta.Kind = "Namespace"
-
-	return ns, nil
-}
-
-// listControlPlaneNamespaces lists all control plane namespaces.
-// TODO: utility function.
-func listControlPlaneNamespaces(client kubernetes.Interface) (*corev1.NamespaceList, error) {
-	requireControlPlaneLabel, err := labels.NewRequirement(constants.ControlPlaneLabel, selection.Exists, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	selector := labels.NewSelector()
-	selector = selector.Add(*requireControlPlaneLabel)
-
-	nss, err := client.CoreV1().Namespaces().List(context.TODO(), metav1.ListOptions{LabelSelector: selector.String()})
-	if err != nil {
-		return nil, err
-	}
-
-	// TODO: this is caused by doing a typed read/decode, if we do this unstructured
-	// using a dynamic client we'll have a happier time.
-	nss.TypeMeta.APIVersion = "v1"
-	nss.TypeMeta.Kind = "NamespaceList"
-
-	return nss, nil
-}
-
 type getControlPlaneOptions struct {
+	// project allows scoping of control plane searching.
+	project string
+
 	// name allows explict filtering of control plane namespaces.
 	names []string
 
-	// printFlags gives a rich set of functionality shamelessly stolen from
-	// kubectl e.g. -o yaml etc.
-	printFlags *get.PrintFlags
+	// getPrintFlags is a generic and reduced set of printing options.
+	getPrintFlags *getPrintFlags
+
+	// f is the factory used to create clients.
+	f cmdutil.Factory
 
 	// client is the Kubernetes v1 client.
 	client kubernetes.Interface
+
+	// unikornClient gives access to our custom resources.
+	unikornClient unikorn.Interface
 }
 
 // newGetControlPlaneOptions returns a correctly initialized set of options.
 func newGetControlPlaneOptions() *getControlPlaneOptions {
 	return &getControlPlaneOptions{
-		printFlags: get.NewGetPrintFlags(),
+		getPrintFlags: newGetPrintFlags(),
 	}
+}
+
+// addFlags registers create cluster options flags with the specified cobra command.
+func (o *getControlPlaneOptions) addFlags(f cmdutil.Factory, cmd *cobra.Command) {
+	cmd.Flags().StringVar(&o.project, "project", "", "Kubernetes project name that contains the control plane.")
+
+	if err := cmd.MarkFlagRequired("project"); err != nil {
+		panic(err)
+	}
+
+	if err := cmd.RegisterFlagCompletionFunc("project", completion.ResourceNameCompletionFunc(f, unikornv1alpha1.ProjectResource)); err != nil {
+		panic(err)
+	}
+
+	o.getPrintFlags.addFlags(cmd)
 }
 
 // complete fills in any options not does automatically by flag parsing.
 func (o *getControlPlaneOptions) complete(f cmdutil.Factory, args []string) error {
+	o.f = f
+
 	var err error
 
 	if o.client, err = f.KubernetesClientSet(); err != nil {
+		return err
+	}
+
+	config, err := f.ToRESTConfig()
+	if err != nil {
+		return err
+	}
+
+	if o.unikornClient, err = unikorn.NewForConfig(config); err != nil {
 		return err
 	}
 
@@ -127,62 +116,127 @@ func (o *getControlPlaneOptions) validate() error {
 		}
 	}
 
+	if len(o.project) == 0 {
+		return fmt.Errorf(`%w: "%s"`, errors.ErrInvalidName, o.project)
+	}
+
 	return nil
 }
 
 // run executes the command.
 func (o *getControlPlaneOptions) run() error {
-	var result runtime.Object
-
-	if o.names != nil {
-		if len(o.names) == 1 {
-			ns, err := getControlPlaneNamespace(o.client, o.names[0])
-			if err != nil {
-				return err
-			}
-
-			result = ns
-		} else {
-			nss := &corev1.NamespaceList{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "v1",
-					Kind:       "NamespaceList",
-				},
-			}
-
-			for _, name := range o.names {
-				ns, err := getControlPlaneNamespace(o.client, name)
-				if err != nil {
-					return err
-				}
-
-				nss.Items = append(nss.Items, *ns)
-			}
-
-			result = nss
-		}
-	} else {
-		nss, err := listControlPlaneNamespaces(o.client)
-		if err != nil {
-			return err
-		}
-
-		result = nss
-	}
-
-	// TODO: we can use the kubectl TablePrinter here, that consumes metav1.Table
-	// resources for better control over the output.  Custom columns are okay, but
-	// cannot do cool stuff ike AGE fields etc.
-	printer, err := o.printFlags.ToPrinter()
+	project, err := o.unikornClient.UnikornV1alpha1().Projects().Get(context.TODO(), o.project, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
 
-	if err := printer.PrintObj(result, os.Stdout); err != nil {
+	namespace := project.Status.Namespace
+	if len(namespace) == 0 {
+		return fmt.Errorf("project namespace undefined")
+	}
+
+	// We are using the "kubectl get" library to retrieve resources.  That command
+	// is generic, it accepts a kind and name(s), or a list of type/name tuples.
+	// In our case, the type is implicit, so we need to prepend it to keep things
+	// working as they should.
+	args := []string{unikornv1alpha1.ControlPlaneResource}
+	args = append(args, o.names...)
+
+	r := o.f.NewBuilder().
+		Unstructured().
+		NamespaceParam(namespace).
+		ResourceTypeOrNameArgs(true, args...).
+		ContinueOnError().
+		Latest().
+		Flatten().
+		TransformRequests(o.getPrintFlags.transformRequests).
+		Do()
+
+	if err := r.Err(); err != nil {
+		return err
+	}
+
+	infos, err := r.Infos()
+	if err != nil {
+		return err
+	}
+
+	// Assume we have a single object, the r.Err above will crap out if no results are
+	// found.  We know all returned results will be projects.  If doing a human printable
+	// get, then a single table will be returned.  If getting by name, especially multiple
+	// names, then there may be multiple results.  Coalesce these into a single list
+	// as that's what is expected from standard tools.
+	object := infos[0].Object
+
+	if len(infos) > 1 {
+		list := &corev1.List{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "List",
+			},
+		}
+
+		for _, info := range infos {
+			list.Items = append(list.Items, runtime.RawExtension{Object: info.Object})
+		}
+
+		object = list
+	}
+
+	printer, err := o.getPrintFlags.toPrinter()
+	if err != nil {
+		return err
+	}
+
+	if err := printer.PrintObj(object, os.Stdout); err != nil {
 		return err
 	}
 
 	return nil
+}
+
+// getControlPlanesCompletionFunc is a bit messy but allows us to do the project
+// to namespace indirection, as the default namespace in the Factory cannot
+// be overridden and we cannot use the generic function provided by kubectl.
+// Obviously this will get worse when we have vcluster to battle against as that
+// needs a whole new kubeconfig.
+func (o *getControlPlaneOptions) getControlPlanesCompletionFunc(f cmdutil.Factory) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		config, err := f.ToRESTConfig()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		unikornClient, err := unikorn.NewForConfig(config)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		project, err := unikornClient.UnikornV1alpha1().Projects().Get(context.TODO(), o.project, metav1.GetOptions{})
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		namespace := project.Status.Namespace
+		if len(namespace) == 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		controlPlanes, err := unikornClient.UnikornV1alpha1().ControlPlanes(namespace).List(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		var matches []string
+
+		for _, cp := range controlPlanes.Items {
+			if strings.HasPrefix(cp.Name, toComplete) {
+				matches = append(matches, cp.Name)
+			}
+		}
+
+		return matches, cobra.ShellCompDirectiveNoFileComp
+	}
 }
 
 // newGetControlPlaneCommand returns a command that is able to get or list Cluster API
@@ -191,31 +245,10 @@ func newGetControlPlaneCommand(f cmdutil.Factory) *cobra.Command {
 	o := newGetControlPlaneOptions()
 
 	cmd := &cobra.Command{
-		Use:   "control-plane",
-		Short: "Get or list Cluster API control planes",
-		Long:  "Get or list Cluster API control planes",
-		// TODO: utility function.
-		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			client, err := f.KubernetesClientSet()
-			if err != nil {
-				return nil, cobra.ShellCompDirectiveError
-			}
-
-			nss, err := listControlPlaneNamespaces(client)
-			if err != nil {
-				return nil, cobra.ShellCompDirectiveError
-			}
-
-			var matches []string
-
-			for _, ns := range nss.Items {
-				if strings.HasPrefix(ns.Name, toComplete) {
-					matches = append(matches, ns.Name)
-				}
-			}
-
-			return matches, cobra.ShellCompDirectiveNoFileComp
-		},
+		Use:               "control-plane",
+		Short:             "Get or list Cluster API control planes",
+		Long:              "Get or list Cluster API control planes",
+		ValidArgsFunction: o.getControlPlanesCompletionFunc(f),
 		Aliases: []string{
 			"control-planes",
 			"cp",
@@ -227,7 +260,7 @@ func newGetControlPlaneCommand(f cmdutil.Factory) *cobra.Command {
 		},
 	}
 
-	o.printFlags.AddFlags(cmd)
+	o.addFlags(f, cmd)
 
 	return cmd
 }

--- a/pkg/cmd/get/get_flags.go
+++ b/pkg/cmd/get/get_flags.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2022 EscherCloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package get
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/cli-runtime/pkg/printers"
+	"k8s.io/client-go/rest"
+	"k8s.io/kubectl/pkg/cmd/get"
+)
+
+type getPrintFlags struct {
+	// outputFormat selects formatting e.g. json, yaml, or human readable by default.
+	outputFormat string
+
+	// jsonYamlPrintFlags specifies any json/yaml formatting options.
+	jsonYamlPrintFlags *genericclioptions.JSONYamlPrintFlags
+
+	// humanReadableFlags allows the default table output format to be tweaked.
+	humanReadableFlags *get.HumanPrintFlags
+}
+
+func newGetPrintFlags() *getPrintFlags {
+	return &getPrintFlags{
+		jsonYamlPrintFlags: genericclioptions.NewJSONYamlPrintFlags(),
+		humanReadableFlags: get.NewHumanPrintFlags(),
+	}
+}
+
+// allowedFormats specifies the possible formats for the output format flag.
+func (o *getPrintFlags) allowedFormats() []string {
+	var formats []string
+
+	formats = append(formats, o.jsonYamlPrintFlags.AllowedFormats()...)
+	formats = append(formats, o.humanReadableFlags.AllowedFormats()...)
+
+	return formats
+}
+
+// outputCompletion is a shell completion function for the output format flag.
+func (o *getPrintFlags) outputCompletion(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	var matches []string
+
+	for _, format := range o.allowedFormats() {
+		if strings.HasPrefix(format, toComplete) {
+			matches = append(matches, format)
+		}
+	}
+
+	return matches, cobra.ShellCompDirectiveNoFileComp
+}
+
+// addFlags registers create cluster options flags with the specified cobra command.
+func (o *getPrintFlags) addFlags(cmd *cobra.Command) {
+	cmd.Flags().StringVarP(&o.outputFormat, "output", "o", "", fmt.Sprintf("Output format. One of (%s)", strings.Join(o.allowedFormats(), ", ")))
+
+	o.jsonYamlPrintFlags.AddFlags(cmd)
+	o.humanReadableFlags.AddFlags(cmd)
+
+	if err := cmd.RegisterFlagCompletionFunc("output", o.outputCompletion); err != nil {
+		panic(err)
+	}
+}
+
+// toPrinter returns the correct printer for the given output format.
+func (o *getPrintFlags) toPrinter() (printers.ResourcePrinter, error) {
+	if printer, err := o.jsonYamlPrintFlags.ToPrinter(o.outputFormat); !genericclioptions.IsNoCompatiblePrinterError(err) {
+		return printer, err
+	}
+
+	if printer, err := o.humanReadableFlags.ToPrinter(o.outputFormat); !genericclioptions.IsNoCompatiblePrinterError(err) {
+		return &get.TablePrinter{Delegate: printer}, err
+	}
+
+	return nil, genericclioptions.NoCompatiblePrinterError{OutputFormat: &o.outputFormat, AllowedFormats: o.allowedFormats()}
+}
+
+// humanReadableOutput indicates whether the output is human readable (server formatted
+// as a table using additional printer columns), or machine readable (e.g. JSON, YAML).
+func (o *getPrintFlags) humanReadableOutput() bool {
+	return len(o.outputFormat) == 0
+}
+
+// transformRequests requests the Kubernetes API return a formatted table when
+// we are requesting human readable output.  This does server side expansion of
+// additional printer columns from the CRDs.
+func (o *getPrintFlags) transformRequests(req *rest.Request) {
+	if !o.humanReadableOutput() {
+		return
+	}
+
+	req.SetHeader("Accept", strings.Join([]string{
+		fmt.Sprintf("application/json;as=Table;v=%s;g=%s", metav1.SchemeGroupVersion.Version, metav1.GroupName),
+		"application/json",
+	}, ","))
+}


### PR DESCRIPTION
First up this requires a refactor of the print flags stuff so it can be shared aross multiple resource types.  Second, this prototypes what it's like having a namespace indirection involved in the process, not pretty as it would turn out, but acceptable.