### PR TITLE
Control Plane Provisioning Fixes

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -28,7 +28,6 @@ linters:
   - godox
   - funlen
   - predeclared
-  - cyclop
 linters-settings:
   gci:
     sections:

--- a/hack/install_metallb/main.go
+++ b/hack/install_metallb/main.go
@@ -28,8 +28,7 @@ import (
 
 	"github.com/spf13/pflag"
 
-	"github.com/eschercloudai/unikorn/pkg/util/provisioners"
-	"github.com/eschercloudai/unikorn/pkg/util/retry"
+	provisioners "github.com/eschercloudai/unikorn/pkg/util/provisioners/generic"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -82,7 +81,7 @@ func waitCondition(c context.Context, client dynamic.Interface, group, version, 
 
 	checker := provisioners.NewStatusConditionReady(client, gvr, namespace, name, conditionType)
 
-	if err := retry.Forever().DoWithContext(c, checker.Check); err != nil {
+	if err := provisioners.NewReadinessCheckWithRetry(checker).Check(c); err != nil {
 		panic(err)
 	}
 }
@@ -92,7 +91,7 @@ func waitCondition(c context.Context, client dynamic.Interface, group, version, 
 func waitDaemonSetReady(c context.Context, client kubernetes.Interface, namespace, name string) {
 	checker := provisioners.NewDaemonSetReady(client, namespace, name)
 
-	if err := retry.Forever().DoWithContext(c, checker.Check); err != nil {
+	if err := provisioners.NewReadinessCheckWithRetry(checker).Check(c); err != nil {
 		panic(err)
 	}
 }
@@ -101,7 +100,7 @@ func waitDaemonSetReady(c context.Context, client kubernetes.Interface, namespac
 func applyManifest(config *genericclioptions.ConfigFlags, path string) {
 	provisioner := provisioners.NewManifestProvisioner(config, path)
 
-	if err := provisioner.Provision(); err != nil {
+	if err := provisioner.Provision(context.TODO()); err != nil {
 		panic(err)
 	}
 }

--- a/pkg/cmd/create/create_project.go
+++ b/pkg/cmd/create/create_project.go
@@ -26,11 +26,11 @@ import (
 	"github.com/eschercloudai/unikorn/pkg/cmd/errors"
 	"github.com/eschercloudai/unikorn/pkg/cmd/util"
 	"github.com/eschercloudai/unikorn/pkg/constants"
+	uniutil "github.com/eschercloudai/unikorn/pkg/util"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/kubernetes/scheme"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/templates"
 )
@@ -133,16 +133,10 @@ func (o *createProjectOptions) run() error {
 		return err
 	}
 
-	gvks, _, err := scheme.Scheme.ObjectKinds(project)
+	gvk, err := uniutil.ObjectGroupVersionKind(project)
 	if err != nil {
 		return err
 	}
-
-	if len(gvks) != 1 {
-		panic("unexpectedly got multiple gvks for object")
-	}
-
-	gvk := gvks[0]
 
 	// The namespace name is auto generated, and will be reflected in the Project
 	// status.  Internally we'll use a label to reference the project in order to
@@ -156,7 +150,7 @@ func (o *createProjectOptions) run() error {
 				constants.ControlPlaneLabel: o.name,
 			},
 			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(project, gvk),
+				*metav1.NewControllerRef(project, *gvk),
 			},
 		},
 	}

--- a/pkg/cmd/get/get_kubeconfig.go
+++ b/pkg/cmd/get/get_kubeconfig.go
@@ -29,7 +29,7 @@ import (
 	"github.com/eschercloudai/unikorn/pkg/cmd/errors"
 	"github.com/eschercloudai/unikorn/pkg/cmd/util"
 	"github.com/eschercloudai/unikorn/pkg/cmd/util/completion"
-	"github.com/eschercloudai/unikorn/pkg/util/vcluster"
+	"github.com/eschercloudai/unikorn/pkg/util/provisioners/vcluster"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"

--- a/pkg/util/provisioners/generic/interfaces.go
+++ b/pkg/util/provisioners/generic/interfaces.go
@@ -14,7 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package provisioners
+package generic
+
+import (
+	"context"
+)
 
 // Provisioner is an abstract type that allows provisioning of Kubernetes
 // packages in a technology agnostic way.  For example some things may be
@@ -22,7 +26,7 @@ package provisioners
 type Provisioner interface {
 	// Provision deploys the requested package.
 	// Implementations should ensure this receiver is idempotent.
-	Provision() error
+	Provision(context.Context) error
 }
 
 // ReadinessCheck is an abstract way of reasoning about the readiness of
@@ -32,5 +36,5 @@ type Provisioner interface {
 type ReadinessCheck interface {
 	// Check performs a single iteration of a readiness check.
 	// Retries are delegated to the caller.
-	Check() error
+	Check(context.Context) error
 }

--- a/pkg/util/provisioners/generic/provisioner_binary.go
+++ b/pkg/util/provisioners/generic/provisioner_binary.go
@@ -14,50 +14,54 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package provisioners
+package generic
 
 import (
+	"context"
+	"fmt"
 	"os/exec"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 )
 
-// ManifestProvisioner uses "kubectl apply" to provision the resources.
-// We use raw config flags here as we can pass them directly to the
-// underlying kubectl command.  We could use a higher level abstraction
-// here, like kubectl's cmdutil.Factory, but then we'd just have to create
-// a temporary kubeconfig.  We could also just hook into kubectl's apply
-// logic, which would be a better solution long term, but time...
-// TODO: some manifests may not have a namspace, we may want to allow
-// overriding this.
-type ManifestProvisioner struct {
+// BinaryProvisioner runs a binary to install a package.
+// This is considered bad practice as it's essentially a black box, and we
+// have limited control over how things are installed from a compliance
+// perspective.
+type BinaryProvisioner struct {
 	// config allows access to the provided kubeconfig, context etc.
 	// TODO: this is not aware of ClientConfigLoadingRules so environment
 	// variables will be ignored for now.
 	config *genericclioptions.ConfigFlags
 
-	// path is the path to the YAML manifest.
-	path string
+	// command is the command to run.
+	command string
+
+	// args are any required arguments.
+	args []string
 }
 
 // Ensure the Provisioner interface is implemented.
-var _ Provisioner = &ManifestProvisioner{}
+var _ Provisioner = &BinaryProvisioner{}
 
-// NewManifestProvisioner returns a new provisioner that is capable of applying
-// a manifest with kubectl.  The path argument may be a path on the local file
-// system or a URL.
-func NewManifestProvisioner(config *genericclioptions.ConfigFlags, path string) *ManifestProvisioner {
-	return &ManifestProvisioner{
-		config: config,
-		path:   path,
+// NewBinaryProvisioner returns a provisioner that installs a component or package
+// with a binary installer.
+func NewBinaryProvisioner(config *genericclioptions.ConfigFlags, command string, args ...string) *BinaryProvisioner {
+	return &BinaryProvisioner{
+		config:  config,
+		command: command,
+		args:    args,
 	}
 }
 
 // Provision implements the Provision interface.
-func (p *ManifestProvisioner) Provision() error {
+func (p *BinaryProvisioner) Provision(_ context.Context) error {
 	var args []string
 
+	/* TODO: there is no way to get this information from a cobra command...
 	// If explcitly specified in the top level command, use these
+	// TODO: some binaries may choose not to implement these flags, or more
+	// annoyingly call them something else.
 	if len(*p.config.KubeConfig) > 0 {
 		args = append(args, "--kubeconfig", *p.config.KubeConfig)
 	}
@@ -65,10 +69,15 @@ func (p *ManifestProvisioner) Provision() error {
 	if len(*p.config.Context) > 0 {
 		args = append(args, "--context", *p.config.Context)
 	}
+	*/
 
-	args = append(args, "apply", "-f", p.path)
+	args = append(args, p.args...)
 
-	if err := exec.Command("kubectl", args...).Run(); err != nil {
+	//nolint:gosec
+	out, err := exec.Command(p.command, args...).CombinedOutput()
+	if err != nil {
+		fmt.Println(string(out))
+
 		return err
 	}
 

--- a/pkg/util/provisioners/generic/provisioner_helm.go
+++ b/pkg/util/provisioners/generic/provisioner_helm.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package provisioners
+package generic
 
 import (
 	"context"
@@ -81,7 +81,7 @@ func NewHelmProvisioner(f cmdutil.Factory, repo, chart, namespace, name string, 
 }
 
 // Provision implements the Provision interface.
-func (p *HelmProvisioner) Provision() error {
+func (p *HelmProvisioner) Provision(ctx context.Context) error {
 	args := []string{
 		"template", p.name, p.chart,
 		"--repo", p.repo,
@@ -135,7 +135,7 @@ func (p *HelmProvisioner) Provision() error {
 			return ErrUnsupportedScope
 		}
 
-		if _, err := client.Resource(mapping.Resource).Namespace(p.namespace).Create(context.TODO(), object, metav1.CreateOptions{}); err != nil {
+		if _, err := client.Resource(mapping.Resource).Namespace(p.namespace).Create(ctx, object, metav1.CreateOptions{}); err != nil {
 			return err
 		}
 	}

--- a/pkg/util/provisioners/generic/readiness_daemonset.go
+++ b/pkg/util/provisioners/generic/readiness_daemonset.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package provisioners
+package generic
 
 import (
 	"context"
@@ -26,10 +26,10 @@ import (
 )
 
 var (
-	ErrStatefulSetUnready = errors.New("statefulset readiness doesn't match desired")
+	ErrDaemonSetUnready = errors.New("daemonset readiness doesn't match desired")
 )
 
-type StatefulSetReady struct {
+type DaemonSetReady struct {
 	// client is an intialized Kubernetes client.
 	client kubernetes.Interface
 
@@ -41,11 +41,11 @@ type StatefulSetReady struct {
 }
 
 // Ensure the ReadinessCheck interface is implemented.
-var _ ReadinessCheck = &StatefulSetReady{}
+var _ ReadinessCheck = &DaemonSetReady{}
 
-// NewStatefulSetReady creates a new statefulset readiness check.
-func NewStatefulSetReady(client kubernetes.Interface, namespace, name string) *StatefulSetReady {
-	return &StatefulSetReady{
+// NewDaemonSetReady creates a new daemonset readiness check.
+func NewDaemonSetReady(client kubernetes.Interface, namespace, name string) *DaemonSetReady {
+	return &DaemonSetReady{
 		client:    client,
 		namespace: namespace,
 		name:      name,
@@ -53,21 +53,14 @@ func NewStatefulSetReady(client kubernetes.Interface, namespace, name string) *S
 }
 
 // Check implements the ReadinessCheck interface.
-func (r *StatefulSetReady) Check() error {
-	statefulset, err := r.client.AppsV1().StatefulSets(r.namespace).Get(context.TODO(), r.name, metav1.GetOptions{})
+func (r *DaemonSetReady) Check(ctx context.Context) error {
+	daemonset, err := r.client.AppsV1().DaemonSets(r.namespace).Get(ctx, r.name, metav1.GetOptions{})
 	if err != nil {
-		return fmt.Errorf("statefulset get error: %w", err)
+		return fmt.Errorf("daemonset get error: %w", err)
 	}
 
-	// k8s.io/api/apps/v1/types.go indicates this defaults to 1.
-	replicas := int32(1)
-
-	if statefulset.Spec.Replicas != nil {
-		replicas = *statefulset.Spec.Replicas
-	}
-
-	if statefulset.Status.ReadyReplicas != replicas {
-		return fmt.Errorf("%w: status mismatch", ErrStatefulSetUnready)
+	if daemonset.Status.NumberReady != daemonset.Status.DesiredNumberScheduled {
+		return fmt.Errorf("%w: status mismatch", ErrDaemonSetUnready)
 	}
 
 	return nil

--- a/pkg/util/provisioners/generic/readiness_retrier.go
+++ b/pkg/util/provisioners/generic/readiness_retrier.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2022 EscherCloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package generic
+
+import (
+	"context"
+
+	"github.com/eschercloudai/unikorn/pkg/util/retry"
+)
+
+// ReadinessCheckWithRetry wraps a readiness check in a retry loop.
+type ReadinessCheckWithRetry struct {
+	// delegate is a backend readiness check to be retried.
+	delegate ReadinessCheck
+}
+
+// Ensure the ReadinessCheck interface is implemented.
+var _ ReadinessCheck = &ReadinessCheckWithRetry{}
+
+// NewReadinessCheckWithRetry returns a new readiness check that will retry.
+func NewReadinessCheckWithRetry(delegate ReadinessCheck) *ReadinessCheckWithRetry {
+	return &ReadinessCheckWithRetry{
+		delegate: delegate,
+	}
+}
+
+// Check implements the ReadinessCheck interface.
+func (r *ReadinessCheckWithRetry) Check(ctx context.Context) error {
+	ready := func() error {
+		return r.delegate.Check(ctx)
+	}
+
+	if err := retry.Forever().DoWithContext(ctx, ready); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/util/provisioners/generic/readiness_statefulset.go
+++ b/pkg/util/provisioners/generic/readiness_statefulset.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package provisioners
+package generic
 
 import (
 	"context"
@@ -26,10 +26,10 @@ import (
 )
 
 var (
-	ErrDaemonSetUnready = errors.New("daemonset readiness doesn't match desired")
+	ErrStatefulSetUnready = errors.New("statefulset readiness doesn't match desired")
 )
 
-type DaemonSetReady struct {
+type StatefulSetReady struct {
 	// client is an intialized Kubernetes client.
 	client kubernetes.Interface
 
@@ -41,11 +41,11 @@ type DaemonSetReady struct {
 }
 
 // Ensure the ReadinessCheck interface is implemented.
-var _ ReadinessCheck = &DaemonSetReady{}
+var _ ReadinessCheck = &StatefulSetReady{}
 
-// NewDaemonSetReady creates a new daemonset readiness check.
-func NewDaemonSetReady(client kubernetes.Interface, namespace, name string) *DaemonSetReady {
-	return &DaemonSetReady{
+// NewStatefulSetReady creates a new statefulset readiness check.
+func NewStatefulSetReady(client kubernetes.Interface, namespace, name string) *StatefulSetReady {
+	return &StatefulSetReady{
 		client:    client,
 		namespace: namespace,
 		name:      name,
@@ -53,14 +53,21 @@ func NewDaemonSetReady(client kubernetes.Interface, namespace, name string) *Dae
 }
 
 // Check implements the ReadinessCheck interface.
-func (r *DaemonSetReady) Check() error {
-	daemonset, err := r.client.AppsV1().DaemonSets(r.namespace).Get(context.TODO(), r.name, metav1.GetOptions{})
+func (r *StatefulSetReady) Check(ctx context.Context) error {
+	statefulset, err := r.client.AppsV1().StatefulSets(r.namespace).Get(ctx, r.name, metav1.GetOptions{})
 	if err != nil {
-		return fmt.Errorf("daemonset get error: %w", err)
+		return fmt.Errorf("statefulset get error: %w", err)
 	}
 
-	if daemonset.Status.NumberReady != daemonset.Status.DesiredNumberScheduled {
-		return fmt.Errorf("%w: status mismatch", ErrDaemonSetUnready)
+	// k8s.io/api/apps/v1/types.go indicates this defaults to 1.
+	replicas := int32(1)
+
+	if statefulset.Spec.Replicas != nil {
+		replicas = *statefulset.Spec.Replicas
+	}
+
+	if statefulset.Status.ReadyReplicas != replicas {
+		return fmt.Errorf("%w: status mismatch", ErrStatefulSetUnready)
 	}
 
 	return nil

--- a/pkg/util/provisioners/generic/readiness_status_condition.go
+++ b/pkg/util/provisioners/generic/readiness_status_condition.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package provisioners
+package generic
 
 import (
 	"context"
@@ -79,8 +79,8 @@ func NewStatusConditionReady(client dynamic.Interface, gvr schema.GroupVersionRe
 }
 
 // Check implements the ReadinessCheck interface.
-func (r *StatusConditionReady) Check() error {
-	object, err := r.client.Resource(r.gvr).Namespace(r.namespace).Get(context.TODO(), r.name, metav1.GetOptions{})
+func (r *StatusConditionReady) Check(ctx context.Context) error {
+	object, err := r.client.Resource(r.gvr).Namespace(r.namespace).Get(ctx, r.name, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/util/provisioners/vcluster/config.go
+++ b/pkg/util/provisioners/vcluster/config.go
@@ -25,6 +25,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
@@ -33,6 +34,16 @@ var (
 	ErrConfigDataMissing          = errors.New("config data not found")
 	ErrLoadBalancerIngressMissing = errors.New("ingress address not found")
 )
+
+func RESTClient(c context.Context, client kubernetes.Interface, namespace, name string) (*rest.Config, error) {
+	return clientcmd.BuildConfigFromKubeconfigGetter("", KubeConfigGetter(c, client, namespace, name))
+}
+
+func KubeConfigGetter(c context.Context, client kubernetes.Interface, namespace, name string) clientcmd.KubeconfigGetter {
+	return func() (*clientcmdapi.Config, error) {
+		return GetConfig(c, client, namespace, name)
+	}
+}
 
 // GetConfig acknowledges that vcluster configuration is synchronized by a side car, so it
 // performs a retry until the provided context expires.  It also acknowledges that load

--- a/pkg/util/provisioners/vcluster/provisioner.go
+++ b/pkg/util/provisioners/vcluster/provisioner.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2022 EscherCloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vcluster
+
+import (
+	"context"
+
+	unikornv1alpha1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
+	"github.com/eschercloudai/unikorn/pkg/util"
+	"github.com/eschercloudai/unikorn/pkg/util/provisioners/generic"
+	"github.com/eschercloudai/unikorn/pkg/util/retry"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+)
+
+const (
+	// vclusterHelmRepo defines loft.sh's repo, sourced from vclusterctl.
+	vclusterHelmRepo = "https://charts.loft.sh"
+
+	// vclusterHelmChart defines the vclustre hlm chart, sourced from vclusterctl.
+	vclusterHelmChart = "vcluster"
+)
+
+// Provisioner wraps up a whole load of horror code required to
+// get vcluster into a deployed and usable state.
+type Provisioner struct {
+	// clients provides access to Kubernetes.
+	clients cmdutil.Factory
+
+	// controlPlane is the control plane resource this belongs to.
+	// Resource names and namespaces are derived from this object.
+	controlPlane *unikornv1alpha1.ControlPlane
+}
+
+// NewProvisioner returns a new initialized provisioner object.
+func NewProvisioner(clients cmdutil.Factory, controlPlane *unikornv1alpha1.ControlPlane) *Provisioner {
+	return &Provisioner{
+		clients:      clients,
+		controlPlane: controlPlane,
+	}
+}
+
+// Ensure the Provisioner interface is implemented.
+var _ generic.Provisioner = &Provisioner{}
+
+// Provision implements the Provision interface.
+func (p *Provisioner) Provision(ctx context.Context) error {
+	name := p.controlPlane.Name
+	namespace := p.controlPlane.Namespace
+
+	client, err := p.clients.KubernetesClientSet()
+	if err != nil {
+		return err
+	}
+
+	// Setup the provisioned with a reference to the control plane so it
+	// is torn down when the control plane is.
+	gvk, err := util.ObjectGroupVersionKind(p.controlPlane)
+	if err != nil {
+		return err
+	}
+
+	ownerReferences := []metav1.OwnerReference{
+		*metav1.NewControllerRef(p.controlPlane, *gvk),
+	}
+
+	// Expose the Kubernetes API as a LoadBalancer service, this will give
+	// end users the ability to provision their own CAPI clusters short term.
+	args := []string{
+		"--set=service.type=LoadBalancer",
+	}
+
+	provisioner := generic.NewHelmProvisioner(p.clients, vclusterHelmRepo, vclusterHelmChart, namespace, name, args, ownerReferences)
+
+	if err := provisioner.Provision(ctx); err != nil {
+		return err
+	}
+
+	// TODO: this is inconsistent, perhaps we just want to use Factory everywhere??
+	statefulsetReadiness := generic.NewStatefulSetReady(client, namespace, name)
+
+	if err := generic.NewReadinessCheckWithRetry(statefulsetReadiness).Check(ctx); err != nil {
+		return err
+	}
+
+	// The stateful set will provision a PVC to contain the Kubernetes "etcd"
+	// database, and these don't get cleaned up, so reusing the same control
+	// plane name will then go off and provision a load of stuff due to persistence.
+	// There is an extension where you can cascade deletion, but as of writing (v1.25)
+	// it's still in alpha.  For now, we manually link the PVC to the control plane.
+	// TODO: we should inspect the stateful set for size, and also the volume name.
+	pvc, err := client.CoreV1().PersistentVolumeClaims(namespace).Get(ctx, "data-"+name+"-0", metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	pvc.SetOwnerReferences(ownerReferences)
+
+	if _, err := client.CoreV1().PersistentVolumeClaims(namespace).Update(ctx, pvc, metav1.UpdateOptions{}); err != nil {
+		return err
+	}
+
+	// So regardless of whether the stateful set is up and running we need to do another
+	// connectivity check because Neutron takes an age to actually provide it.
+	if err := p.waitForNetwork(ctx, client, namespace, name); err != nil {
+		return err
+	}
+
+	return err
+}
+
+// waitForNetwork does that, polls the VCluster API endpoint and waits for it to
+// start working.
+func (p *Provisioner) waitForNetwork(ctx context.Context, client kubernetes.Interface, namespace, name string) error {
+	vclusterRESTClient, err := RESTClient(ctx, client, namespace, name)
+	if err != nil {
+		return err
+	}
+
+	vclusterClient, err := kubernetes.NewForConfig(vclusterRESTClient)
+	if err != nil {
+		return err
+	}
+
+	wait := func() error {
+		if _, err := vclusterClient.Discovery().ServerVersion(); err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	if err := retry.Forever().DoWithContext(ctx, wait); err != nil {
+		return err
+	}
+
+	return err
+}

--- a/pkg/util/retry/retry.go
+++ b/pkg/util/retry/retry.go
@@ -18,6 +18,7 @@ package retry
 
 import (
 	"context"
+	"fmt"
 	"time"
 )
 
@@ -67,12 +68,14 @@ func (r *Retrier) DoWithContext(c context.Context, f Callback) error {
 	t := time.NewTicker(r.period)
 	defer t.Stop()
 
+	var rerr error
+
 	for {
 		select {
 		case <-c.Done():
-			return c.Err()
+			return fmt.Errorf("%w: last error: %s", c.Err(), rerr.Error())
 		case <-t.C:
-			if err := f(); err != nil {
+			if rerr = f(); rerr != nil {
 				break
 			}
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2022 EscherCloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"errors"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+var (
+	// ErrUnversionedGroupVersionKind is returned when the GVK is
+	// unversioned.
+	ErrUnversionedGroupVersionKind = errors.New("gvk is unversioned")
+
+	// ErrAmbiguousGroupVersionKind is returned when more than one GVK
+	// is returned for a type.
+	ErrAmbiguousGroupVersionKind = errors.New("gvk is ambiguous")
+)
+
+// ObjectGroupVersionKind returns a GVK from a Kubernetes typed resource using
+// scheme translation.
+func ObjectGroupVersionKind(o runtime.Object) (*schema.GroupVersionKind, error) {
+	gvks, unversioned, err := scheme.Scheme.ObjectKinds(o)
+	if err != nil {
+		return nil, err
+	}
+
+	if unversioned {
+		return nil, ErrUnversionedGroupVersionKind
+	}
+
+	if len(gvks) != 1 {
+		return nil, ErrAmbiguousGroupVersionKind
+	}
+
+	return &gvks[0], nil
+}


### PR DESCRIPTION
The core of this is to make a specialised provisioner for vcluster. This rights the wrongs of the past by attaching owner references to the PVCs on provision so they get cleaned up on control plane deletion, and also adds in a network connectivity check to ensure vcluster is reachable before kicking off the CAPI install.  Other tweaks involve a readiness retrier and propagating contexts far better.