### PR TITLE
Add CR Finalizers

### DIFF
--- a/pkg/cmd/create/create_control_plane.go
+++ b/pkg/cmd/create/create_control_plane.go
@@ -133,6 +133,9 @@ func (o *createControlPlaneOptions) run() error {
 			Labels: map[string]string{
 				constants.VersionLabel: constants.Version,
 			},
+			Finalizers: []string{
+				metav1.FinalizerDeleteDependents,
+			},
 		},
 	}
 
@@ -180,9 +183,6 @@ func (o *createControlPlaneOptions) run() error {
 
 	fmt.Println("🦄 Provisioning Cluster API ...")
 
-	// TODO: the fact a VIP has been provisioned is no guarantee that you can actually
-	// contact the Kubernetes API (especially talking to you Neutron).  We should do
-	// a TCP/HTTP connectivity check before continuing.
 	// TODO: we need a better provisioner for this.
 	clusterAPIProvisioner := provisioners.NewBinaryProvisioner(nil, "clusterctl", "init", "--kubeconfig", configPath, "--infrastructure", "openstack", "--wait-providers")
 

--- a/pkg/cmd/create/create_project.go
+++ b/pkg/cmd/create/create_project.go
@@ -102,6 +102,9 @@ func (o *createProjectOptions) run() error {
 			Labels: map[string]string{
 				constants.VersionLabel: constants.Version,
 			},
+			Finalizers: []string{
+				metav1.FinalizerDeleteDependents,
+			},
 		},
 		Spec: unikornv1alpha1.ProjectSpec{
 			ProjectID: o.projectID,


### PR DESCRIPTION
By default, the owner references attached to created resources will cause a parent resource to block deletion until all dependents are done too, iff you specfify foreground deletion when deleting the parent.  Or in this case, we pre-bake it in.  This prevents a deletion and recreation of say a control plane where child resource names alias and it causes a failure.  One could argue that child resource names should be generated to prevent collision, in the same vein as project namespaces are generated and you need to do an indirection.