### PR TITLE
Enhance Container Security

### DIFF
--- a/docker/unikorn-control-plane-manager/.dockerignore
+++ b/docker/unikorn-control-plane-manager/.dockerignore
@@ -1,3 +1,4 @@
 *
 !bin/amd64-linux-gnu/unikorn-control-plane-manager
 !manifests/controlplane
+!hack/passwd.nonroot

--- a/docker/unikorn-control-plane-manager/Dockerfile
+++ b/docker/unikorn-control-plane-manager/Dockerfile
@@ -2,5 +2,8 @@ FROM scratch
 
 COPY bin/amd64-linux-gnu/unikorn-control-plane-manager /
 COPY manifests/controlplane /manifests/
+COPY hack/passwd.nonroot /etc/passwd
+
+USER 1000
 
 ENTRYPOINT ["/unikorn-control-plane-manager"]

--- a/docker/unikorn-project-manager/.dockerignore
+++ b/docker/unikorn-project-manager/.dockerignore
@@ -1,2 +1,3 @@
 *
 !bin/amd64-linux-gnu/unikorn-project-manager
+!hack/passwd.nonroot

--- a/docker/unikorn-project-manager/Dockerfile
+++ b/docker/unikorn-project-manager/Dockerfile
@@ -1,5 +1,8 @@
 FROM scratch
 
 COPY bin/amd64-linux-gnu/unikorn-project-manager /
+COPY hack/passwd.nonroot /etc/passwd
+
+USER 1000
 
 ENTRYPOINT ["/unikorn-project-manager"]

--- a/hack/passwd.nonroot
+++ b/hack/passwd.nonroot
@@ -1,0 +1,1 @@
+unikorn:x:1000:1000:Unikorn Non Root,,,::

--- a/manifests/unikorn-control-plane-manager.yaml
+++ b/manifests/unikorn-control-plane-manager.yaml
@@ -49,7 +49,11 @@ spec:
         ports:
         - name: prometheus
           containerPort: 8080
+        securityContext:
+          readOnlyRootFilesystem: true
       serviceAccountName: unikorn-control-plane-manager
+      securityContext:
+        runAsNonRoot: true
 ---
 apiVersion: v1
 kind: Service

--- a/manifests/unikorn-project-manager.yaml
+++ b/manifests/unikorn-project-manager.yaml
@@ -80,7 +80,11 @@ spec:
         ports:
         - name: prometheus
           containerPort: 8080
+        securityContext:
+          readOnlyRootFilesystem: true
       serviceAccountName: unikorn-project-manager
+      securityContext:
+        runAsNonRoot: true
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
It's a scratch container as it is, so there's very little to make use of, but in case the applications are themselves compromised, prevent any filesystem modifications by making it read only.  Also jump through the non-root hoops so the underlying platform is protected too.