### PR TITLE
Grafana Dash Installer

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -20,6 +20,11 @@ helm install prometheus prometheus-community/kube-prometheus-stack --namespace m
 This will pretty much work out of the box.
 See [`manifests/prometheus.yaml`](https://github.com/eschercloudai/unikorn/blob/main/manifests/prometheus.yaml) for an example of use, using the wonderful Prometheus Operator.
 
+### Installing Unikorn Dashboard
+
+There's a rudimentary Grafana dashboard for the Unikorn controller componenets available in tree.
+Run [`grafana/install`](https://github.com/eschercloudai/unikorn/blob/main/grafana/install) with a default `kube-prometheus-stack` to automagically have it appear.
+
 ## Metrics Server
 
 The prometheus stuff has some good metrics collected by default, and the Unikorn binaries give a decent view into heap allocations.

--- a/grafana/install
+++ b/grafana/install
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+NAMESPACE=monitoring
+
+while getopts "n:" opt; do
+	case ${opt} in
+		n) NAMESPACE=${OPTARG};;
+	esac
+done
+
+kubectl -n ${NAMESPACE} create configmap unikorn --from-file=k8s-dashboard.json=grafana/unikorn.json
+kubectl -n ${NAMESPACE} label configmap unikorn grafana_dashboard=1


### PR DESCRIPTION
Add a simple script that installs the Unikorn dashboard via a config map, then labels it so it gets picked up by the Grafana sidecar.