### PR TITLE
Nuke projectID

### DIFF
--- a/crds/unikorn.eschercloud.ai_projects.yaml
+++ b/crds/unikorn.eschercloud.ai_projects.yaml
@@ -16,9 +16,6 @@ spec:
   scope: Cluster
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .spec.projectId
-      name: projectid
-      type: string
     - jsonPath: .status.namespace
       name: namespace
       type: string
@@ -48,13 +45,6 @@ spec:
             type: object
           spec:
             description: ProjectSpec defines project specific metadata.
-            properties:
-              projectId:
-                description: ProjectID is the lobally unique project identifier. This
-                  is intended to be managed by an external system.
-                type: string
-            required:
-            - projectId
             type: object
           status:
             description: ProjectStatus defines the status of the project.

--- a/pkg/apis/unikorn/v1alpha1/types.go
+++ b/pkg/apis/unikorn/v1alpha1/types.go
@@ -165,7 +165,6 @@ type ProjectList struct {
 // +kubebuilder:resource:categories=all;eschercloud
 // +kubebuilder:resource:scope=Cluster
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="projectid",type="string",JSONPath=".spec.projectId"
 // +kubebuilder:printcolumn:name="namespace",type="string",JSONPath=".status.namespace"
 // +kubebuilder:printcolumn:name="status",type="string",JSONPath=".status.conditions[?(@.type==\"Provisioned\")].reason"
 // +kubebuilder:printcolumn:name="age",type="date",JSONPath=".metadata.creationTimestamp"
@@ -178,9 +177,6 @@ type Project struct {
 
 // ProjectSpec defines project specific metadata.
 type ProjectSpec struct {
-	// ProjectID is the lobally unique project identifier. This is intended to be
-	// managed by an external system.
-	ProjectID string `json:"projectId"`
 }
 
 // ProjectStatus defines the status of the project.

--- a/pkg/cmd/create/create_project.go
+++ b/pkg/cmd/create/create_project.go
@@ -37,23 +37,11 @@ type createProjectOptions struct {
 	// name is the name of the project to create.
 	name string
 
-	// projectID is the external management plane's project identifier.
-	projectID string
-
 	// client is the Kubernetes v1 client.
 	client kubernetes.Interface
 
 	// unikornClient gives access to our custom resources.
 	unikornClient unikorn.Interface
-}
-
-// addFlags registers create cluster options flags with the specified cobra command.
-func (o *createProjectOptions) addFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.projectID, "project", "", "management plane project identifier.")
-
-	if err := cmd.MarkFlagRequired("project"); err != nil {
-		panic(err)
-	}
 }
 
 // complete fills in any options not does automatically by flag parsing.
@@ -104,9 +92,6 @@ func (o *createProjectOptions) run() error {
 				metav1.FinalizerDeleteDependents,
 			},
 		},
-		Spec: unikornv1alpha1.ProjectSpec{
-			ProjectID: o.projectID,
-		},
 	}
 
 	if _, err := o.unikornClient.UnikornV1alpha1().Projects().Create(context.TODO(), project, metav1.CreateOptions{}); err != nil {
@@ -156,8 +141,6 @@ func newCreateProjectCommand(f cmdutil.Factory) *cobra.Command {
 			util.AssertNilError(o.run())
 		},
 	}
-
-	o.addFlags(cmd)
 
 	return cmd
 }


### PR DESCRIPTION
Simplify things by removing the superfluous (for now) projectID from the Project spec, plus associated bits.