### PR TITLE
Make Cluster Provisioning Work

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,21 +93,6 @@ the CRs.
 kubectl apply -f crds
 ```
 
-#### Installing Cert Manager CRDs
-
-tl;dr do this.
-The long version is that dynamic clients will perform an API resource lookup on start up.
-This will initialse REST mapping from APIVersion/Kind to REST endpoints.
-Now, it transpires that you need to install Cert-Manager resources to provision Cluster API.
-In order to do that, the REST mapper needs to know about `Certificate` custom resources on startup.
-To facilitate this, just install them on the management cluster:
-
-```shell
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.10.0/cert-manager.crds.yaml
-```
-
-While it is possible to redo a discovery when a CRD is provisioned, the controller-runtime makes it practically impossible without forcing a container restart.
-
 #### Installing the Unikorn Controllers
 
 There are a couple manifests -- one per controller -- in the `manifests` directory.

--- a/manifests/cluster/cluster-api-cluster-openstack/patches.json
+++ b/manifests/cluster/cluster-api-cluster-openstack/patches.json
@@ -15,5 +15,13 @@
 		"patches": [
 			{"op":"replace","path":"/spec/nodeCidr","value":"${OPENSTACK_NODE_NETWORK}"}
 		]
+	},
+	{
+		"description": "Remove the Kubeadm image repository",
+		"apiVersion": "controlplane.cluster.x-k8s.io/v1beta1",
+		"kind": "KubeadmControlPlane",
+		"patches": [
+			{"op":"remove","path":"/spec/kubeadmConfigSpec/clusterConfiguration/imageRepository"}
+		]
 	}
 ]

--- a/pkg/provisioners/cluster/provisioner.go
+++ b/pkg/provisioners/cluster/provisioner.go
@@ -56,7 +56,8 @@ func (p *Provisioner) Provision(ctx context.Context) error {
 		return err
 	}
 
-	vclusterClient, err := client.New(vclusterConfig, client.Options{Scheme: p.client.Scheme(), Mapper: p.client.RESTMapper()})
+	// Do not inherit the scheme or REST mapper here, it's a different cluster!
+	vclusterClient, err := client.New(vclusterConfig, client.Options{})
 	if err != nil {
 		return err
 	}
@@ -91,7 +92,7 @@ func (p *Provisioner) Provision(ctx context.Context) error {
 		return ""
 	}
 
-	provisioner := provisioners.NewManifestProvisioner(vclusterClient, provisioners.ManifestProviderOpenstackKubernetesCluster).WithEnvMapper(envMapper)
+	provisioner := provisioners.NewManifestProvisioner(vclusterClient, provisioners.ManifestProviderOpenstackKubernetesCluster).WithNamespace("default").WithEnvMapper(envMapper)
 
 	if err := provisioner.Provision(ctx); err != nil {
 		return err

--- a/pkg/provisioners/controlplane/provisioner.go
+++ b/pkg/provisioners/controlplane/provisioner.go
@@ -86,7 +86,8 @@ func (p *Provisioner) Provision(ctx context.Context) error {
 		return err
 	}
 
-	vclusterClient, err := client.New(vclusterConfig, client.Options{Scheme: p.client.Scheme(), Mapper: p.client.RESTMapper()})
+	// Do not inherit the scheme or REST mapper here, it's a different cluster!
+	vclusterClient, err := client.New(vclusterConfig, client.Options{})
 	if err != nil {
 		return err
 	}

--- a/pkg/provisioners/provisioner_manifest.go
+++ b/pkg/provisioners/provisioner_manifest.go
@@ -425,6 +425,14 @@ func (p *ManifestProvisioner) provision(ctx context.Context, objects []unstructu
 	for i := range objects {
 		object := &objects[i]
 
+		if object.GetNamespace() == "" {
+			if p.namespace == "" {
+				panic("object has no namespace and none provided")
+			}
+
+			object.SetNamespace(p.namespace)
+		}
+
 		if p.ownerReferences != nil {
 			object.SetOwnerReferences(p.ownerReferences)
 		}


### PR DESCRIPTION
The main fix here was to have vcluster clients reinitialise their dynamic clients against the target cluster, so it picks up the CRDs installed there.  Unbeknownst to me, it will also refresh the REST mapper when it encounters something unknown, which is pretty awesome. Other than that, remove a broken image repository from the cluster manifest and fix the cluster provider configuration for kubelet.