### PR TITLE
Get Cluster Deletion Working(ish)

### DIFF
--- a/crds/unikorn.eschercloud.ai_controlplanes.yaml
+++ b/crds/unikorn.eschercloud.ai_controlplanes.yaml
@@ -9,6 +9,9 @@ metadata:
 spec:
   group: unikorn.eschercloud.ai
   names:
+    categories:
+    - all
+    - unikorn
     kind: ControlPlane
     listKind: ControlPlaneList
     plural: controlplanes
@@ -16,6 +19,9 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
+    - jsonPath: .status.namespace
+      name: namespace
+      type: string
     - jsonPath: .status.conditions[?(@.type=="Available")].reason
       name: status
       type: string
@@ -93,6 +99,10 @@ spec:
                   - type
                   type: object
                 type: array
+              namespace:
+                description: Namespace defines the namespace a control plane resides
+                  in.
+                type: string
             type: object
         required:
         - spec

--- a/crds/unikorn.eschercloud.ai_kubernetesclusters.yaml
+++ b/crds/unikorn.eschercloud.ai_kubernetesclusters.yaml
@@ -9,6 +9,9 @@ metadata:
 spec:
   group: unikorn.eschercloud.ai
   names:
+    categories:
+    - all
+    - unikorn
     kind: KubernetesCluster
     listKind: KubernetesClusterList
     plural: kubernetesclusters
@@ -16,8 +19,8 @@ spec:
   scope: Namespaced
   versions:
   - additionalPrinterColumns:
-    - jsonPath: .metadata.labels['unikorn\.eschercloud\.ai/controlplane']
-      name: controlPlane
+    - jsonPath: .status.namespace
+      name: namespace
       type: string
     - jsonPath: .spec.kubernetesVersion
       name: version
@@ -236,6 +239,9 @@ spec:
                   - type
                   type: object
                 type: array
+              namespace:
+                description: Namespace defines the namespace a cluster resides in.
+                type: string
             type: object
         required:
         - spec

--- a/crds/unikorn.eschercloud.ai_projects.yaml
+++ b/crds/unikorn.eschercloud.ai_projects.yaml
@@ -9,6 +9,9 @@ metadata:
 spec:
   group: unikorn.eschercloud.ai
   names:
+    categories:
+    - all
+    - unikorn
     kind: Project
     listKind: ProjectList
     plural: projects
@@ -19,7 +22,7 @@ spec:
     - jsonPath: .status.namespace
       name: namespace
       type: string
-    - jsonPath: .status.conditions[?(@.type=="Provisioned")].reason
+    - jsonPath: .status.conditions[?(@.type=="Available")].reason
       name: status
       type: string
     - jsonPath: .metadata.creationTimestamp
@@ -65,6 +68,12 @@ spec:
                     reason:
                       description: Unique, one-word, CamelCase reason for the condition's
                         last transition.
+                      enum:
+                      - Provisioning
+                      - Provisioned
+                      - Canceled
+                      - Timedout
+                      - Errored
                       type: string
                     status:
                       description: Status is the status of the condition. Can be True,
@@ -73,7 +82,7 @@ spec:
                     type:
                       description: Type is the type of the condition.
                       enum:
-                      - Provisioned
+                      - Available
                       type: string
                   required:
                   - lastTransitionTime

--- a/manifests/unikorn-project-manager.yaml
+++ b/manifests/unikorn-project-manager.yaml
@@ -16,6 +16,16 @@ rules:
   - list
   - get
   - watch
+  - update
+- apiGroups:
+  - unikorn.eschercloud.ai
+  resources:
+  - controlplanes
+  verbs:
+  - list
+  - get
+  - watch
+  - delete
 - apiGroups:
   - unikorn.eschercloud.ai
   resources:
@@ -36,6 +46,7 @@ rules:
   - namespaces
   verbs:
   - create
+  - get
   - list
   - watch
   - delete

--- a/pkg/apis/unikorn/v1alpha1/helpers.go
+++ b/pkg/apis/unikorn/v1alpha1/helpers.go
@@ -42,6 +42,56 @@ func IPv4AddressSliceFromIPSlice(in []net.IP) []IPv4Address {
 
 // LookupCondition scans the status conditions for an existing condition whose type
 // matches.  Returns the array index, or -1 if it doesn't exist.
+func (c *Project) LookupCondition(t ProjectConditionType) (*ProjectCondition, error) {
+	for i, condition := range c.Status.Conditions {
+		if condition.Type == t {
+			return &c.Status.Conditions[i], nil
+		}
+	}
+
+	return nil, ErrStatusConditionLookup
+}
+
+// UpdateCondition either adds or updates a condition in the control plane status.
+// If the condition, status and message match an existing condition the update is
+// ignored.  Returns true if a modification has been made.
+func (c *Project) UpdateCondition(t ProjectConditionType, status corev1.ConditionStatus, reason ProjectConditionReason, message string) bool {
+	condition := ProjectCondition{
+		Type:               t,
+		Status:             status,
+		LastTransitionTime: metav1.Now(),
+		Reason:             reason,
+		Message:            message,
+	}
+
+	existingPtr, err := c.LookupCondition(t)
+	if err != nil {
+		c.Status.Conditions = append(c.Status.Conditions, condition)
+
+		return true
+	}
+
+	// Do a shallow copy and set the same time, then do a shallow equality to
+	// see if we need an update.
+	existing := *existingPtr
+	existing.LastTransitionTime = condition.LastTransitionTime
+
+	if existing != condition {
+		*existingPtr = condition
+
+		return true
+	}
+
+	return false
+}
+
+// UpdateAvailableCondition updates the Available condition specifically.
+func (c *Project) UpdateAvailableCondition(status corev1.ConditionStatus, reason ProjectConditionReason, message string) bool {
+	return c.UpdateCondition(ProjectConditionAvailable, status, reason, message)
+}
+
+// LookupCondition scans the status conditions for an existing condition whose type
+// matches.  Returns the array index, or -1 if it doesn't exist.
 func (c *ControlPlane) LookupCondition(t ControlPlaneConditionType) (*ControlPlaneCondition, error) {
 	for i, condition := range c.Status.Conditions {
 		if condition.Type == t {
@@ -85,6 +135,57 @@ func (c *ControlPlane) UpdateCondition(t ControlPlaneConditionType, status corev
 	return false
 }
 
+// UpdateAvailableCondition updates the Available condition specifically.
 func (c *ControlPlane) UpdateAvailableCondition(status corev1.ConditionStatus, reason ControlPlaneConditionReason, message string) bool {
 	return c.UpdateCondition(ControlPlaneConditionAvailable, status, reason, message)
+}
+
+// LookupCondition scans the status conditions for an existing condition whose type
+// matches.  Returns the array index, or -1 if it doesn't exist.
+func (c *KubernetesCluster) LookupCondition(t KubernetesClusterConditionType) (*KubernetesClusterCondition, error) {
+	for i, condition := range c.Status.Conditions {
+		if condition.Type == t {
+			return &c.Status.Conditions[i], nil
+		}
+	}
+
+	return nil, ErrStatusConditionLookup
+}
+
+// UpdateCondition either adds or updates a condition in the cluster status.
+// If the condition, status and message match an existing condition the update is
+// ignored.  Returns true if a modification has been made.
+func (c *KubernetesCluster) UpdateCondition(t KubernetesClusterConditionType, status corev1.ConditionStatus, reason KubernetesClusterConditionReason, message string) bool {
+	condition := KubernetesClusterCondition{
+		Type:               t,
+		Status:             status,
+		LastTransitionTime: metav1.Now(),
+		Reason:             reason,
+		Message:            message,
+	}
+
+	existingPtr, err := c.LookupCondition(t)
+	if err != nil {
+		c.Status.Conditions = append(c.Status.Conditions, condition)
+
+		return true
+	}
+
+	// Do a shallow copy and set the same time, then do a shallow equality to
+	// see if we need an update.
+	existing := *existingPtr
+	existing.LastTransitionTime = condition.LastTransitionTime
+
+	if existing != condition {
+		*existingPtr = condition
+
+		return true
+	}
+
+	return false
+}
+
+// UpdateAvailableCondition updates the Available condition specifically.
+func (c *KubernetesCluster) UpdateAvailableCondition(status corev1.ConditionStatus, reason KubernetesClusterConditionReason, message string) bool {
+	return c.UpdateCondition(KubernetesClusterConditionAvailable, status, reason, message)
 }

--- a/pkg/cmd/create/create_control_plane.go
+++ b/pkg/cmd/create/create_control_plane.go
@@ -89,15 +89,9 @@ func (o *createControlPlaneOptions) validate() error {
 
 // run executes the command.
 func (o *createControlPlaneOptions) run() error {
-	project, err := o.client.UnikornV1alpha1().Projects().Get(context.TODO(), o.project, metav1.GetOptions{})
+	namespace, err := util.GetProjectNamespace(context.TODO(), o.client, o.project)
 	if err != nil {
 		return err
-	}
-
-	namespace := project.Status.Namespace
-
-	if len(namespace) == 0 {
-		panic("achtung!")
 	}
 
 	controlPlane := &unikornv1alpha1.ControlPlane{
@@ -105,9 +99,6 @@ func (o *createControlPlaneOptions) run() error {
 			Name: o.name,
 			Labels: map[string]string{
 				constants.VersionLabel: constants.Version,
-			},
-			Finalizers: []string{
-				metav1.FinalizerDeleteDependents,
 			},
 		},
 	}

--- a/pkg/cmd/create/create_project.go
+++ b/pkg/cmd/create/create_project.go
@@ -88,9 +88,6 @@ func (o *createProjectOptions) run() error {
 			Labels: map[string]string{
 				constants.VersionLabel: constants.Version,
 			},
-			Finalizers: []string{
-				metav1.FinalizerDeleteDependents,
-			},
 		},
 	}
 

--- a/pkg/cmd/delete/delete_cluster.go
+++ b/pkg/cmd/delete/delete_cluster.go
@@ -17,28 +17,82 @@ limitations under the License.
 package delete
 
 import (
+	"context"
+
 	"github.com/spf13/cobra"
 
+	"github.com/eschercloudai/unikorn/generated/clientset/unikorn"
+	unikornv1alpha1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
+	"github.com/eschercloudai/unikorn/pkg/cmd/errors"
 	"github.com/eschercloudai/unikorn/pkg/cmd/util"
+	"github.com/eschercloudai/unikorn/pkg/cmd/util/completion"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	computil "k8s.io/kubectl/pkg/util/completion"
 )
 
 // deleteClusterOptions defines a set of options that are required to delete
 // a cluster.
 type deleteClusterOptions struct {
+	// project defines the project to delete the cluster from.
+	project string
+
 	// controlPlane defines the control plane name that the cluster will
-	// be deprovisioned from.
+	// be deleted from.
 	controlPlane string
+
+	// name is the name of the cluster.
+	name string
+
+	// client gives access to our custom resources.
+	client unikorn.Interface
 }
 
 // addFlags registers delete cluster options flags with the specified cobra command.
-func (o *deleteClusterOptions) addFlags(cmd *cobra.Command) {
-	cmd.Flags().StringVar(&o.controlPlane, "control-plane", "", "Control plane to deprovision the cluster from.")
+func (o *deleteClusterOptions) addFlags(f cmdutil.Factory, cmd *cobra.Command) {
+	util.RequiredStringVarWithCompletion(cmd, &o.project, "project", "", "Kubernetes project name that contains the control plane.", computil.ResourceNameCompletionFunc(f, unikornv1alpha1.ProjectResource))
+	util.RequiredStringVarWithCompletion(cmd, &o.controlPlane, "control-plane", "", "Control plane to deprovision the cluster from.", completion.ControlPlanesCompletionFunc(f, &o.project))
+}
 
-	if err := cmd.MarkFlagRequired("control-plane"); err != nil {
-		panic(err)
+// complete fills in any options not does automatically by flag parsing.
+func (o *deleteClusterOptions) complete(f cmdutil.Factory, args []string) error {
+	config, err := f.ToRESTConfig()
+	if err != nil {
+		return err
 	}
+
+	if o.client, err = unikorn.NewForConfig(config); err != nil {
+		return err
+	}
+
+	if len(args) != 1 {
+		return errors.ErrIncorrectArgumentNum
+	}
+
+	o.name = args[0]
+
+	return nil
+}
+
+// validate validates any tainted input not handled by complete() or flags
+// processing.
+func (o *deleteClusterOptions) validate() error {
+	return nil
+}
+
+// run executes the command.
+func (o *deleteClusterOptions) run() error {
+	namespace, err := util.GetControlPlaneNamespace(context.TODO(), o.client, o.project, o.controlPlane)
+	if err != nil {
+		return err
+	}
+
+	if err := o.client.UnikornV1alpha1().KubernetesClusters(namespace).Delete(context.TODO(), o.name, metav1.DeleteOptions{}); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 var (
@@ -50,19 +104,23 @@ var (
 
 // newDeleteClusterCommand creates a command that deletes a Kubenretes cluster in the
 // specified Cluster API control plane.
-func newDeleteClusterCommand(_ cmdutil.Factory) *cobra.Command {
+func newDeleteClusterCommand(f cmdutil.Factory) *cobra.Command {
 	o := &deleteClusterOptions{}
 
 	cmd := &cobra.Command{
-		Use:     "cluster",
-		Short:   "Delete a Kubernetes cluster",
-		Long:    "Delete a Kubernetes cluster",
-		Example: deleteClusterExamples,
+		Use:               "cluster",
+		Short:             "Delete a Kubernetes cluster",
+		Long:              "Delete a Kubernetes cluster",
+		Example:           deleteClusterExamples,
+		ValidArgsFunction: completion.ClustersCompletionFunc(f, &o.project, &o.controlPlane),
 		Run: func(cmd *cobra.Command, args []string) {
+			util.AssertNilError(o.complete(f, args))
+			util.AssertNilError(o.validate())
+			util.AssertNilError(o.run())
 		},
 	}
 
-	o.addFlags(cmd)
+	o.addFlags(f, cmd)
 
 	return cmd
 }

--- a/pkg/cmd/delete/delete_control_plane.go
+++ b/pkg/cmd/delete/delete_control_plane.go
@@ -93,14 +93,9 @@ func (o *deleteControlPlaneOptions) validate() error {
 
 // run executes the command.
 func (o *deleteControlPlaneOptions) run() error {
-	project, err := o.unikornClient.UnikornV1alpha1().Projects().Get(context.TODO(), o.project, metav1.GetOptions{})
+	namespace, err := util.GetProjectNamespace(context.TODO(), o.unikornClient, o.project)
 	if err != nil {
 		return err
-	}
-
-	namespace := project.Status.Namespace
-	if len(namespace) == 0 {
-		return errors.ErrProjectNamespaceUndefined
 	}
 
 	if err := o.unikornClient.UnikornV1alpha1().ControlPlanes(namespace).Delete(context.TODO(), o.name, metav1.DeleteOptions{}); err != nil {

--- a/pkg/cmd/get/get_control_plane.go
+++ b/pkg/cmd/get/get_control_plane.go
@@ -28,7 +28,6 @@ import (
 	"github.com/eschercloudai/unikorn/pkg/cmd/util"
 	"github.com/eschercloudai/unikorn/pkg/cmd/util/completion"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	computil "k8s.io/kubectl/pkg/util/completion"
 )
@@ -112,14 +111,9 @@ func (o *getControlPlaneOptions) validate() error {
 
 // run executes the command.
 func (o *getControlPlaneOptions) run() error {
-	project, err := o.client.UnikornV1alpha1().Projects().Get(context.TODO(), o.project, metav1.GetOptions{})
+	namespace, err := util.GetProjectNamespace(context.TODO(), o.client, o.project)
 	if err != nil {
 		return err
-	}
-
-	namespace := project.Status.Namespace
-	if len(namespace) == 0 {
-		return errors.ErrProjectNamespaceUndefined
 	}
 
 	// We are using the "kubectl get" library to retrieve resources.  That command

--- a/pkg/cmd/get/get_kubeconfig.go
+++ b/pkg/cmd/get/get_kubeconfig.go
@@ -31,7 +31,6 @@ import (
 	"github.com/eschercloudai/unikorn/pkg/cmd/util/completion"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/vcluster"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	computil "k8s.io/kubectl/pkg/util/completion"
@@ -104,17 +103,12 @@ func (o *getKubeConfigOptions) validate() error {
 
 // run executes the command.
 func (o *getKubeConfigOptions) run() error {
-	project, err := o.unikornClient.UnikornV1alpha1().Projects().Get(context.TODO(), o.project, metav1.GetOptions{})
+	namespace, err := util.GetControlPlaneNamespace(context.TODO(), o.unikornClient, o.project, o.name)
 	if err != nil {
 		return err
 	}
 
-	namespace := project.Status.Namespace
-	if len(namespace) == 0 {
-		return errors.ErrProjectNamespaceUndefined
-	}
-
-	configPath, cleanup, err := vcluster.WriteConfig(context.TODO(), vcluster.NewKubectlGetter(o.client), namespace, o.name)
+	configPath, cleanup, err := vcluster.WriteConfig(context.TODO(), vcluster.NewKubectlGetter(o.client), namespace)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/get/printer.go
+++ b/pkg/cmd/get/printer.go
@@ -17,6 +17,7 @@ limitations under the License.
 package get
 
 import (
+	"fmt"
 	"os"
 
 	corev1 "k8s.io/api/core/v1"
@@ -33,11 +34,16 @@ func (o *getPrintFlags) printResult(r *resource.Result) error {
 		return err
 	}
 
-	// Assume we have a single object, the r.Err above will crap out if no results are
-	// found.  We know all returned results will be projects.  If doing a human printable
-	// get, then a single table will be returned.  If getting by name, especially multiple
-	// names, then there may be multiple results.  Coalesce these into a single list
-	// as that's what is expected from standard tools.
+	if len(infos) == 0 {
+		fmt.Println("no resources found")
+
+		return nil
+	}
+
+	// If doing a human printable get, then a single table will be returned.
+	// If getting by name, especially multiple names, then there may be multiple
+	// results.  Coalesce these into a single list as that's what is expected from
+	// standard tools.
 	object := infos[0].Object
 
 	if len(infos) > 1 {

--- a/pkg/cmd/util/flags.go
+++ b/pkg/cmd/util/flags.go
@@ -39,15 +39,6 @@ func RequiredVar(cmd *cobra.Command, p pflag.Value, name, usage string) {
 	}
 }
 
-// StringVarWithCompletion registers a string flag with a completion function.
-func StringVarWithCompletion(cmd *cobra.Command, p *string, name, value, usage string, f func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective)) {
-	cmd.Flags().StringVar(p, name, value, usage)
-
-	if err := cmd.RegisterFlagCompletionFunc(name, f); err != nil {
-		panic(err)
-	}
-}
-
 // RequiredStringVarWithCompletion registers a string flag marked as required and
 // with a completion function.
 func RequiredStringVarWithCompletion(cmd *cobra.Command, p *string, name, value, usage string, f func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective)) {

--- a/pkg/cmd/util/indirection.go
+++ b/pkg/cmd/util/indirection.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2022 EscherCloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/eschercloudai/unikorn/generated/clientset/unikorn"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	// ErrUnavailable is for when the resource status reports unready.
+	ErrUnavailable = errors.New("resource unavailable")
+
+	// ErrNamespace is for when the resource status doesn't contain a namespace.
+	ErrNamespace = errors.New("namespace error")
+)
+
+// GetProjectNamespace figures out the namespace associated with a project.
+func GetProjectNamespace(ctx context.Context, client unikorn.Interface, project string) (string, error) {
+	p, err := client.UnikornV1alpha1().Projects().Get(ctx, project, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	namespace := p.Status.Namespace
+
+	if namespace == "" {
+		return "", fmt.Errorf("%w: project namespace unset", ErrNamespace)
+	}
+
+	return namespace, nil
+}
+
+// GetControlPlaneNamespace figures out the namespace associated with a project's control plane.
+func GetControlPlaneNamespace(ctx context.Context, client unikorn.Interface, project, controlPlane string) (string, error) {
+	p, err := client.UnikornV1alpha1().Projects().Get(ctx, project, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	namespace := p.Status.Namespace
+
+	if namespace == "" {
+		return "", fmt.Errorf("%w: project namespace unset", ErrNamespace)
+	}
+
+	cp, err := client.UnikornV1alpha1().ControlPlanes(namespace).Get(ctx, controlPlane, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	namespace = cp.Status.Namespace
+
+	if namespace == "" {
+		return "", fmt.Errorf("%w: control plane namespace unset", ErrNamespace)
+	}
+
+	return namespace, nil
+}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -56,4 +56,12 @@ const (
 	// ControlPlaneLabel is a label applied to resources to indicate is belongs
 	// to a specific control plane.
 	ControlPlaneLabel = "unikorn.eschercloud.ai/controlplane"
+
+	// KubernetesClusterLabel is applied to resources to indicate it belongs
+	// to a specific cluster.
+	KubernetesClusterLabel = "unikorn.eschercloud.ai/cluster"
+
+	// Finalizer is applied to resources that need to be deleted manually
+	// and do other complex logic.
+	Finalizer = "unikorn"
 )

--- a/pkg/managers/cluster/reconcile.go
+++ b/pkg/managers/cluster/reconcile.go
@@ -18,11 +18,16 @@ package cluster
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"time"
 
 	unikornv1alpha1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
+	"github.com/eschercloudai/unikorn/pkg/constants"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/cluster"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -35,14 +40,15 @@ type reconciler struct {
 
 var _ reconcile.Reconciler = &reconciler{}
 
+//nolint:cyclop
 func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := log.FromContext(ctx)
 
 	// See if the resource exists or not, if not it's been deleted, but do nothing
 	// as cascading deletes will handle the cleanup.
-	kubernetesCluster := &unikornv1alpha1.KubernetesCluster{}
-	if err := r.client.Get(ctx, request.NamespacedName, kubernetesCluster); err != nil {
-		if errors.IsNotFound(err) {
+	object := &unikornv1alpha1.KubernetesCluster{}
+	if err := r.client.Get(ctx, request.NamespacedName, object); err != nil {
+		if kerrors.IsNotFound(err) {
 			log.Info("resource deleted")
 
 			return reconcile.Result{}, nil
@@ -51,26 +57,118 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, err
 	}
 
+	provisioner := cluster.New(r.client, object)
+
 	// If it's being deleted, ignore it, we don't need to take any additional action.
-	if kubernetesCluster.DeletionTimestamp != nil {
-		log.V(1).Info("resource deleting")
+	if object.DeletionTimestamp != nil {
+		if len(object.Finalizers) == 0 {
+			return reconcile.Result{}, nil
+		}
+
+		log.Info("resource deleting")
+
+		// TODO: we need to add a status condition to say we are deleting.
+		// And obviously report any errors of course.
+		timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+		defer cancel()
+
+		if err := provisioner.Deprovision(timeoutCtx); err != nil {
+			return reconcile.Result{}, err
+		}
+
+		object.Finalizers = nil
+
+		if err := r.client.Update(ctx, object); err != nil {
+			return reconcile.Result{}, err
+		}
 
 		return reconcile.Result{}, nil
 	}
 
 	log.Info("reconciling resource")
 
+	// Check to see if this is (or appears to be) the first time we've seen a
+	// resource and do observability as appropriate.
+	if err := r.handleReconcileFirstVisit(ctx, object); err != nil {
+		return reconcile.Result{}, err
+	}
+
 	// Create a new context with a status object attached, we'll use this later to
 	// conditionally report provisioning status, and a timeout so we don't hang
 	// forever in retry loops.
-	provisionContext, cancel := context.WithTimeout(ctx, kubernetesCluster.Spec.Timeout.Duration)
+	provisionContext, cancel := context.WithTimeout(ctx, object.Spec.Timeout.Duration)
 	defer cancel()
 
-	provisioner := cluster.New(r.client, kubernetesCluster)
-
 	if err := provisioner.Provision(provisionContext); err != nil {
+		if err := r.handleReconcileError(ctx, object, err); err != nil {
+			return reconcile.Result{}, err
+		}
+
+		return reconcile.Result{}, err
+	}
+
+	if err := r.handleReconcileComplete(ctx, object); err != nil {
 		return reconcile.Result{}, err
 	}
 
 	return reconcile.Result{}, nil
+}
+
+// handleReconcileFirstVisit checks to see if the Available condition is present in the
+// status, if not we assume it's the first time we've seen this an set the condition to
+// Provisioning.
+func (r *reconciler) handleReconcileFirstVisit(ctx context.Context, kubernetesCluster *unikornv1alpha1.KubernetesCluster) error {
+	if _, err := kubernetesCluster.LookupCondition(unikornv1alpha1.KubernetesClusterConditionAvailable); err != nil {
+		kubernetesCluster.Finalizers = []string{
+			constants.Finalizer,
+		}
+
+		kubernetesCluster.UpdateAvailableCondition(corev1.ConditionFalse, unikornv1alpha1.KubernetesClusterConditionReasonProvisioning, "Provisioning of kubernetes cluster has started")
+
+		if err := r.client.Update(ctx, kubernetesCluster); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// handleReconcileComplete indicates that the reconcile is complete and the control
+// plane is ready to be used.
+func (r *reconciler) handleReconcileComplete(ctx context.Context, kubernetesCluster *unikornv1alpha1.KubernetesCluster) error {
+	if ok := kubernetesCluster.UpdateAvailableCondition(corev1.ConditionTrue, unikornv1alpha1.KubernetesClusterConditionReasonProvisioned, "Provisioning of kubernetes cluster has completed"); ok {
+		if err := r.client.Status().Update(ctx, kubernetesCluster); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// handleReconcileError inspects the error type that halted the provisioning and reports
+// this as a ppropriate in the status.
+func (r *reconciler) handleReconcileError(ctx context.Context, kubernetesCluster *unikornv1alpha1.KubernetesCluster, err error) error {
+	var reason unikornv1alpha1.KubernetesClusterConditionReason
+
+	var message string
+
+	switch {
+	case errors.Is(err, context.Canceled):
+		reason = unikornv1alpha1.KubernetesClusterConditionReasonCanceled
+		message = "Provisioning aborted due to controller shudown"
+	case errors.Is(err, context.DeadlineExceeded):
+		reason = unikornv1alpha1.KubernetesClusterConditionReasonTimedout
+		message = fmt.Sprintf("Provisioning aborted due to a timeout: %v", err)
+	default:
+		reason = unikornv1alpha1.KubernetesClusterConditionReasonErrored
+		message = fmt.Sprintf("Provisioning failed due to an error: %v", err)
+	}
+
+	if ok := kubernetesCluster.UpdateAvailableCondition(corev1.ConditionFalse, reason, message); ok {
+		if err := r.client.Status().Update(ctx, kubernetesCluster); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/pkg/managers/controlplane/reconcile.go
+++ b/pkg/managers/controlplane/reconcile.go
@@ -20,8 +20,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	unikornv1alpha1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
+	"github.com/eschercloudai/unikorn/pkg/constants"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/controlplane"
 
 	corev1 "k8s.io/api/core/v1"
@@ -38,13 +40,14 @@ type reconciler struct {
 
 var _ reconcile.Reconciler = &reconciler{}
 
+//nolint:cyclop
 func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := log.FromContext(ctx)
 
 	// See if the resource exists or not, if not it's been deleted, but do nothing
 	// as cascading deletes will handle the cleanup.
-	controlPlane := &unikornv1alpha1.ControlPlane{}
-	if err := r.client.Get(ctx, request.NamespacedName, controlPlane); err != nil {
+	object := &unikornv1alpha1.ControlPlane{}
+	if err := r.client.Get(ctx, request.NamespacedName, object); err != nil {
 		if kerrors.IsNotFound(err) {
 			log.Info("resource deleted")
 
@@ -54,9 +57,30 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, err
 	}
 
+	provisioner := controlplane.New(r.client, object)
+
 	// If it's being deleted, ignore it, we don't need to take any additional action.
-	if controlPlane.DeletionTimestamp != nil {
-		log.V(1).Info("resource deleting")
+	if object.DeletionTimestamp != nil {
+		if len(object.Finalizers) == 0 {
+			return reconcile.Result{}, nil
+		}
+
+		log.Info("resource deleting")
+
+		// TODO: we need to add a status condition to say we are deleting.
+		// And obviously report any errors of course.
+		timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+		defer cancel()
+
+		if err := provisioner.Deprovision(timeoutCtx); err != nil {
+			return reconcile.Result{}, err
+		}
+
+		object.Finalizers = nil
+
+		if err := r.client.Update(ctx, object); err != nil {
+			return reconcile.Result{}, err
+		}
 
 		return reconcile.Result{}, nil
 	}
@@ -65,26 +89,26 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	// Check to see if this is (or appears to be) the first time we've seen a
 	// resource and do observability as appropriate.
-	if err := r.handleReconcileFirstVisit(ctx, controlPlane); err != nil {
+	if err := r.handleReconcileFirstVisit(ctx, object); err != nil {
 		return reconcile.Result{}, err
 	}
 
 	// Create a new context with a status object attached, we'll use this later to
 	// conditionally report provisioning status, and a timeout so we don't hang
 	// forever in retry loops.
-	provisionContext, cancel := context.WithTimeout(ctx, controlPlane.Spec.Timeout.Duration)
+	provisionContext, cancel := context.WithTimeout(ctx, object.Spec.Timeout.Duration)
 	defer cancel()
 
 	// Provision the control plane.
-	if err := controlplane.New(r.client, controlPlane).Provision(provisionContext); err != nil {
-		if err := r.handleReconcileError(ctx, controlPlane, err); err != nil {
+	if err := provisioner.Provision(provisionContext); err != nil {
+		if err := r.handleReconcileError(ctx, object, err); err != nil {
 			return reconcile.Result{}, err
 		}
 
 		return reconcile.Result{}, err
 	}
 
-	if err := r.handleReconcileComplete(ctx, controlPlane); err != nil {
+	if err := r.handleReconcileComplete(ctx, object); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -96,9 +120,13 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 // Provisioning.
 func (r *reconciler) handleReconcileFirstVisit(ctx context.Context, controlPlane *unikornv1alpha1.ControlPlane) error {
 	if _, err := controlPlane.LookupCondition(unikornv1alpha1.ControlPlaneConditionAvailable); err != nil {
+		controlPlane.Finalizers = []string{
+			constants.Finalizer,
+		}
+
 		controlPlane.UpdateAvailableCondition(corev1.ConditionFalse, unikornv1alpha1.ControlPlaneConditionReasonProvisioning, "Provisioning of control plane has started")
 
-		if err := r.client.Status().Update(ctx, controlPlane); err != nil {
+		if err := r.client.Update(ctx, controlPlane); err != nil {
 			return err
 		}
 	}

--- a/pkg/provisioners/clusterapi/provisioner.go
+++ b/pkg/provisioners/clusterapi/provisioner.go
@@ -149,3 +149,8 @@ func (p *Provisioner) Provision(ctx context.Context) error {
 
 	return nil
 }
+
+// Deprovision implements the Provision interface.
+func (p *Provisioner) Deprovision(context.Context) error {
+	return nil
+}

--- a/pkg/provisioners/interfaces.go
+++ b/pkg/provisioners/interfaces.go
@@ -27,6 +27,13 @@ type Provisioner interface {
 	// Provision deploys the requested package.
 	// Implementations should ensure this receiver is idempotent.
 	Provision(context.Context) error
+
+	// Deprovision does any special handling of resource/component
+	// removal.  In the general case, you should rely on cascading
+	// deletion i.e. kill the namespace, use owner references.
+	// Deprovisioners should be gating, waiting for their resources
+	// to be removed before indicating success.
+	Deprovision(context.Context) error
 }
 
 // ReadinessCheck is an abstract way of reasoning about the readiness of

--- a/pkg/provisioners/project/provisioner.go
+++ b/pkg/provisioners/project/provisioner.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2022 EscherCloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package project
+
+import (
+	"context"
+	"errors"
+
+	unikornv1alpha1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
+	"github.com/eschercloudai/unikorn/pkg/constants"
+	"github.com/eschercloudai/unikorn/pkg/provisioners"
+	"github.com/eschercloudai/unikorn/pkg/provisioners/util"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	ErrLabelMissing = errors.New("expected label missing")
+)
+
+// Provisioner encapsulates control plane provisioning.
+type Provisioner struct {
+	// client provides access to Kubernetes.
+	client client.Client
+
+	// project is the Kubernetes project we're provisioning.
+	project *unikornv1alpha1.Project
+}
+
+// New returns a new initialized provisioner object.
+func New(client client.Client, project *unikornv1alpha1.Project) *Provisioner {
+	return &Provisioner{
+		client:  client,
+		project: project,
+	}
+}
+
+// Ensure the Provisioner interface is implemented.
+var _ provisioners.Provisioner = &Provisioner{}
+
+// Provision implements the Provision interface.
+func (p *Provisioner) Provision(ctx context.Context) error {
+	// Namespace exists, leave it alone.
+	_, err := util.GetResourceNamespace(ctx, p.client, constants.ProjectLabel, p.project.Name)
+	if err == nil {
+		return nil
+	}
+
+	// Some other error, propagate it back up the stack.
+	if !errors.Is(err, util.ErrNamespaceLookup) {
+		return err
+	}
+
+	// Create a new project namespace.
+	namespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "project-",
+			Labels: map[string]string{
+				constants.ProjectLabel: p.project.Name,
+			},
+		},
+	}
+
+	if err := provisioners.NewResourceProvisioner(p.client, namespace).Provision(ctx); err != nil {
+		return err
+	}
+
+	p.project.Status.Namespace = namespace.Name
+
+	if err := p.client.Status().Update(ctx, p.project); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Deprovision implements the Provision interface.
+func (p *Provisioner) Deprovision(ctx context.Context) error {
+	// Get the project's namespace.
+	namespace, err := util.GetResourceNamespace(ctx, p.client, constants.ProjectLabel, p.project.Name)
+	if err != nil {
+		// Already dead.
+		if errors.Is(err, util.ErrNamespaceLookup) {
+			return nil
+		}
+
+		return err
+	}
+
+	// Find any control planes and delete them.  They in turn will delete clusters and
+	// free any Openstack resources.
+	controlPlanes := &unikornv1alpha1.ControlPlaneList{}
+	if err := p.client.List(ctx, controlPlanes, &client.ListOptions{Namespace: namespace.Name}); err != nil {
+		return err
+	}
+
+	for i := range controlPlanes.Items {
+		if err := provisioners.NewResourceProvisioner(p.client, &controlPlanes.Items[i]).Deprovision(ctx); err != nil {
+			return err
+		}
+	}
+
+	// Deprovision the namespace and await deletion.
+	if err := provisioners.NewResourceProvisioner(p.client, namespace).Deprovision(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/provisioners/provisioner_kubectl.go
+++ b/pkg/provisioners/provisioner_kubectl.go
@@ -77,3 +77,8 @@ func (p *KubectlProvisioner) Provision(_ context.Context) error {
 
 	return nil
 }
+
+// Deprovision implements the Provision interface.
+func (p *KubectlProvisioner) Deprovision(context.Context) error {
+	return nil
+}

--- a/pkg/provisioners/util/util.go
+++ b/pkg/provisioners/util/util.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2022 EscherCloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	ErrNamespaceLookup = errors.New("unable to lookup namespace")
+)
+
+func GetResourceNamespace(ctx context.Context, cli client.Client, label, name string) (*corev1.Namespace, error) {
+	labelRequirement, err := labels.NewRequirement(label, selection.Equals, []string{name})
+	if err != nil {
+		return nil, err
+	}
+
+	selector := labels.Everything().Add(*labelRequirement)
+
+	namespaces := &corev1.NamespaceList{}
+	if err := cli.List(ctx, namespaces, &client.ListOptions{LabelSelector: selector}); err != nil {
+		return nil, err
+	}
+
+	if len(namespaces.Items) != 1 {
+		return nil, fmt.Errorf("%w: label %s, name %s", ErrNamespaceLookup, label, name)
+	}
+
+	return &namespaces.Items[0], nil
+}

--- a/pkg/readiness/existence.go
+++ b/pkg/readiness/existence.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2022 EscherCloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package readiness
+
+import (
+	"context"
+	"errors"
+
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	ErrResourceExists = errors.New("resource still exists")
+)
+
+type ResourceNotExists struct {
+	client client.Client
+	object client.Object
+}
+
+func NewResourceNotExists(client client.Client, object client.Object) *ResourceNotExists {
+	return &ResourceNotExists{
+		client: client,
+		object: object,
+	}
+}
+
+// Ensure the Check interface is implemented.
+var _ Check = &Deployment{}
+
+// Check implements the Check interface.
+func (r *ResourceNotExists) Check(ctx context.Context) error {
+	objectKey := client.ObjectKeyFromObject(r.object)
+
+	// The Get call needs something to store the result into, it also needs
+	// to be able to derive the GVK, so we just convert the object into an
+	// unstructured resource.  Immutability is not guaranteed when the source
+	// is also unstructured, you have been warned!
+	var resource unstructured.Unstructured
+
+	if err := r.client.Scheme().Convert(r.object, &resource, nil); err != nil {
+		return err
+	}
+
+	if err := r.client.Get(ctx, objectKey, &resource); err != nil {
+		if kerrors.IsNotFound(err) {
+			return nil
+		}
+
+		return err
+	}
+
+	return ErrResourceExists
+}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -17,41 +17,8 @@ limitations under the License.
 package util
 
 import (
-	"errors"
 	"strings"
-
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
-
-var (
-	// ErrUnversionedGroupVersionKind is returned when the GVK is
-	// unversioned.
-	ErrUnversionedGroupVersionKind = errors.New("gvk is unversioned")
-
-	// ErrAmbiguousGroupVersionKind is returned when more than one GVK
-	// is returned for a type.
-	ErrAmbiguousGroupVersionKind = errors.New("gvk is ambiguous")
-)
-
-// ObjectGroupVersionKind returns a GVK from a Kubernetes typed resource using
-// scheme translation.
-func ObjectGroupVersionKind(s *runtime.Scheme, o runtime.Object) (*schema.GroupVersionKind, error) {
-	gvks, unversioned, err := s.ObjectKinds(o)
-	if err != nil {
-		return nil, err
-	}
-
-	if unversioned {
-		return nil, ErrUnversionedGroupVersionKind
-	}
-
-	if len(gvks) != 1 {
-		return nil, ErrAmbiguousGroupVersionKind
-	}
-
-	return &gvks[0], nil
-}
 
 // SplitYAML takes a yaml manifest and splits it into individual objects
 // discarding any empty sections.


### PR DESCRIPTION
The goal here is to have CAPI clean up the OS resources for us. Deleting the namespace doesn't work as that will frag any secrets needed to talk to OS, so we need to be a bit more measured in our approach. The main fix is to add deprovisioners to everything, that allows us to wait until completion.  We use finalizers to provide synchronization. It does actually make a lot of things cleaner, and fixes a few UX bugs are the same time, so win win all around, even though it doesn't fully work yet...