### PR TITLE
Moar Release Fixes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,9 +12,6 @@ env:
 jobs:
   release:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
     steps:
     - name: checkout
       uses: actions/checkout@v3


### PR DESCRIPTION
Seems we need write permissions on the contents to create a release. Assuming we have permissive tokens by default, just removing the permissions entirely should work...