### PR TITLE
Make Helm use GHCR

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,8 +7,6 @@ on:
     - '*'
 env:
   GO_VERSION: 1.19.1
-  REGISTRY: ghcr.io
-  ORGANIZATION: eschercloudai
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -28,7 +26,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     - name: Build and Push Images
-      run: make images-push -e VERSION=${{ github.ref_name }} DOCKER_ORG=${{ env.REGISTRY }}/${{ env.ORGANIZATION }}
+      run: make images-push -e VERSION=${{ github.ref_name }}
     - name: Release
       id: create_release
       uses: actions/create-release@v1

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ GENCLIENTNAME = unikorn
 GENCLIENTS = $(MODULE)/$(GENDIR)/clientset
 
 # This defines how docker containers are tagged.
-DOCKER_ORG = eschercloudai
+DOCKER_ORG = ghcr.io/eschercloudai
 
 # Main target, builds all binaries.
 .PHONY: all

--- a/charts/unikorn/templates/_helpers.tpl
+++ b/charts/unikorn/templates/_helpers.tpl
@@ -73,15 +73,15 @@ Create the container images
 {{- end }}
 
 {{- define "unikorn.projectManagerImage" -}}
-{{- default (printf "%s/unikorn-project-manager:%s" (include "unikorn.defaultRepositoryPath" .) .Values.tag) .Values.projectManager.image }}
+{{- printf "%s/unikorn-project-manager:%s" (include "unikorn.defaultRepositoryPath" .) .Values.tag | default .Values.projectManager.image }}
 {{- end }}
 
 {{- define "unikorn.controlPlaneManagerImage" -}}
-{{- default (printf "%s/unikorn-control-plane-manager:%s" (include "unikorn.defaultRepositoryPath" .) .Values.tag) .Values.controlPlaneManager.image }}
+{{- printf "%s/unikorn-control-plane-manager:%s" (include "unikorn.defaultRepositoryPath" .) .Values.tag | default .Values.controlPlaneManager.image }}
 {{- end }}
 
 {{- define "unikorn.clusterManagerImage" -}}
-{{- default (printf "%s/unikorn-cluster-manager:%s" (include "unikorn.defaultRepositoryPath" .) .Values.tag) .Values.clusterManager.image }}
+{{- printf "%s/unikorn-cluster-manager:%s" (include "unikorn.defaultRepositoryPath" .) .Values.tag | default .Values.clusterManager.image }}
 {{- end }}
 
 {{/*
@@ -98,4 +98,16 @@ prometheus.eschercloud.ai/job
 {{- define "unikorn.prometheusLabels" -}}
 {{ include "unikorn.prometheusServiceSelector" . }}
 {{ include "unikorn.prometheusJobLabel" . }}: {{ .job }}
+{{- end }}
+
+{{/*
+Create image pull secrets
+*/}}
+{{- define "unikorn.imagePullSecrets" -}}
+{{- range .Values.imagePullSecrets -}}
+- name: {{ . }}
+{{ end }}
+{{- range $index, $config := .Values.dockerConfigs -}}
+- name: docker-config-{{ $index }}
+{{ end }}
 {{- end }}

--- a/charts/unikorn/templates/image-pull-secret.yaml
+++ b/charts/unikorn/templates/image-pull-secret.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.dockerConfigs }}
+{{- $dot := . }}
+{{- range $index, $config := .Values.dockerConfigs }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: docker-config-{{ $index }}
+  labels:
+    {{- include "unikorn.labels" $dot | nindent 4 }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ $config }}
+{{- end }}
+{{- end }}

--- a/charts/unikorn/templates/unikorn-cluster-manager.yaml
+++ b/charts/unikorn/templates/unikorn-cluster-manager.yaml
@@ -4,6 +4,10 @@ metadata:
   name: unikorn-cluster-manager
   labels:
     {{- include "unikorn.labels" . | nindent 4 }}
+{{- with ( include "unikorn.imagePullSecrets" . ) }}
+imagePullSecrets:
+{{ . }}
+{{- end }}
 ---
 # Bad, bad Simon
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/unikorn/templates/unikorn-control-plane-manager.yaml
+++ b/charts/unikorn/templates/unikorn-control-plane-manager.yaml
@@ -4,6 +4,10 @@ metadata:
   name: unikorn-control-plane-manager
   labels:
     {{- include "unikorn.labels" . | nindent 4 }}
+{{- with ( include "unikorn.imagePullSecrets" . ) }}
+imagePullSecrets:
+{{ . }}
+{{- end }}
 ---
 # Bad, bad Simon
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/unikorn/templates/unikorn-project-manager.yaml
+++ b/charts/unikorn/templates/unikorn-project-manager.yaml
@@ -4,6 +4,10 @@ metadata:
   name: unikorn-project-manager
   labels:
     {{- include "unikorn.labels" . | nindent 4 }}
+{{- with ( include "unikorn.imagePullSecrets" . ) }}
+imagePullSecrets:
+{{ . }}
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/charts/unikorn/values.yaml
+++ b/charts/unikorn/values.yaml
@@ -5,7 +5,17 @@ repository: ghcr.io
 organization: eschercloudai
 
 # Set the global container tag.
-tag: v0.1.0
+tag: 0.1.0
+
+# Set the docker configuration, doing so will create a secret and link it
+# to the service accounts of all the controllers.  You can do something like:
+# --set dockerConfigs[0]=$(cat ~/.docker/config.json | base64 -d)
+dockerConfigs: []
+
+# Set the image pull secret on the service accounts of all the controllers.
+# This is an alternative to dockerConfigs, but unlikely to play ball with
+# ArgoCD as it's a foreign object that needs pruning.
+imagePullSecrets: []
 
 # Project manager specific configuration.
 projectManager:


### PR DESCRIPTION
Update Makefile to create GHCR images by default, thus simplifying the whole release process.  Update Helm to use the correct semver tag format, then allow the user to either select image pull secrets, or to define managed versions and add them to the service accounts.