### PR TITLE
Add in CNI Provisioning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -77,6 +77,7 @@ require (
 	go.uber.org/zap v1.21.0 // indirect
 	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
+	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -439,6 +439,8 @@ golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
+golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/pkg/argocd/cluster/cluster.go
+++ b/pkg/argocd/cluster/cluster.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2022 EscherCloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cluster
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"net/url"
+
+	argocdapi "github.com/eschercloudai/argocd-client-go/pkg/api"
+
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+var (
+	ErrContextUndefined = errors.New("kubeconfig context undefined")
+)
+
+// Upsert is an idempotent method to create a cluster in ArgoCD from a client config.
+// This is limited to X.509 mutual authentication at present.
+func Upsert(ctx context.Context, client *argocdapi.APIClient, name string, config *clientcmdapi.Config) error {
+	clientContext, ok := config.Contexts[config.CurrentContext]
+	if !ok {
+		return ErrContextUndefined
+	}
+
+	tlsClientConfig := argocdapi.NewV1alpha1TLSClientConfig()
+	tlsClientConfig.SetCaData(base64.StdEncoding.EncodeToString(config.Clusters[clientContext.Cluster].CertificateAuthorityData))
+	tlsClientConfig.SetCertData(base64.StdEncoding.EncodeToString(config.AuthInfos[clientContext.AuthInfo].ClientCertificateData))
+	tlsClientConfig.SetKeyData(base64.StdEncoding.EncodeToString(config.AuthInfos[clientContext.AuthInfo].ClientKeyData))
+
+	clusterConfig := argocdapi.NewV1alpha1ClusterConfig()
+	clusterConfig.SetTlsClientConfig(*tlsClientConfig)
+
+	cluster := argocdapi.NewV1alpha1Cluster()
+	cluster.SetServer(name)
+	cluster.SetConfig(*clusterConfig)
+
+	if _, _, err := client.ClusterServiceApi.ClusterServiceCreate(ctx).Body(*cluster).Upsert(true).Execute(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Delete is an idempotent method to delete a cluster from ArgoCD.
+func Delete(ctx context.Context, client *argocdapi.APIClient, name string) error {
+	// Do a list here, not a get, Argo's schema is bobbins and doesn't handle 404s
+	// as described.
+	clusters, _, err := client.ClusterServiceApi.ClusterServiceList(ctx).Execute()
+	if err != nil {
+		return err
+	}
+
+	for _, cluster := range clusters.Items {
+		if *cluster.Server != name {
+			continue
+		}
+
+		if _, _, err := client.ClusterServiceApi.ClusterServiceDelete(ctx, url.QueryEscape(name)).Execute(); err != nil {
+			return err
+		}
+
+		break
+	}
+
+	return nil
+}

--- a/pkg/provisioners/clusterapi/provisioner.go
+++ b/pkg/provisioners/clusterapi/provisioner.go
@@ -26,7 +26,6 @@ import (
 	"github.com/eschercloudai/unikorn/pkg/provisioners/application"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/labels"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -77,8 +76,8 @@ func (p *Provisioner) WithLabels(l map[string]string) *Provisioner {
 	return p
 }
 
-func (p *Provisioner) getLabels(app string) map[string]string {
-	l := map[string]string{
+func (p *Provisioner) getLabels(app string) map[string]interface{} {
+	l := map[string]interface{}{
 		constants.ApplicationLabel: app,
 	}
 
@@ -202,11 +201,7 @@ func (p *Provisioner) Provision(ctx context.Context) error {
 	// TODO: code repetition.
 	log.Info("provisioning cert manager")
 
-	certManagerApp := p.generateCertManagerApplication()
-
-	certManagerProvisioner := application.New(p.client, certManagerApp, labels.SelectorFromSet(p.getLabels("cert-manager")))
-
-	if err := certManagerProvisioner.Provision(ctx); err != nil {
+	if err := application.New(p.client, p.generateCertManagerApplication()).Provision(ctx); err != nil {
 		return err
 	}
 
@@ -214,11 +209,7 @@ func (p *Provisioner) Provision(ctx context.Context) error {
 
 	log.Info("provisioning cluster API")
 
-	clusterAPIApp := p.generateClusterAPIApplication()
-
-	clusterAPIProvisioner := application.New(p.client, clusterAPIApp, labels.SelectorFromSet(p.getLabels("cluster-api")))
-
-	if err := clusterAPIProvisioner.Provision(ctx); err != nil {
+	if err := application.New(p.client, p.generateClusterAPIApplication()).Provision(ctx); err != nil {
 		return err
 	}
 
@@ -233,11 +224,7 @@ func (p *Provisioner) Deprovision(ctx context.Context) error {
 
 	log.Info("deprovisioning cluster API")
 
-	clusterAPIApp := p.generateClusterAPIApplication()
-
-	clusterAPIProvisioner := application.New(p.client, clusterAPIApp, labels.SelectorFromSet(p.getLabels("cluster-api")))
-
-	if err := clusterAPIProvisioner.Deprovision(ctx); err != nil {
+	if err := application.New(p.client, p.generateClusterAPIApplication()).Deprovision(ctx); err != nil {
 		return err
 	}
 
@@ -245,11 +232,7 @@ func (p *Provisioner) Deprovision(ctx context.Context) error {
 
 	log.Info("deprovisioning cert manager")
 
-	certManagerApp := p.generateCertManagerApplication()
-
-	certManagerProvisioner := application.New(p.client, certManagerApp, labels.SelectorFromSet(p.getLabels("cert-manager")))
-
-	if err := certManagerProvisioner.Deprovision(ctx); err != nil {
+	if err := application.New(p.client, p.generateCertManagerApplication()).Deprovision(ctx); err != nil {
 		return err
 	}
 

--- a/pkg/provisioners/vcluster/provisioner.go
+++ b/pkg/provisioners/vcluster/provisioner.go
@@ -26,7 +26,6 @@ import (
 	"github.com/eschercloudai/unikorn/pkg/provisioners/application"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/labels"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -87,8 +86,8 @@ func (p *Provisioner) WithLabels(l map[string]string) *Provisioner {
 	return p
 }
 
-func (p *Provisioner) getLabels() map[string]string {
-	l := map[string]string{
+func (p *Provisioner) getLabels() map[string]interface{} {
+	l := map[string]interface{}{
 		constants.ApplicationLabel: "vcluster",
 	}
 
@@ -157,11 +156,7 @@ func (p *Provisioner) Provision(ctx context.Context) error {
 
 	log.Info("provisioning vcluster")
 
-	app := p.generateApplication()
-
-	applicationProvisioner := application.New(p.client, app, labels.SelectorFromSet(p.getLabels()))
-
-	if err := applicationProvisioner.Provision(ctx); err != nil {
+	if err := application.New(p.client, p.generateApplication()).Provision(ctx); err != nil {
 		return err
 	}
 
@@ -172,11 +167,7 @@ func (p *Provisioner) Provision(ctx context.Context) error {
 
 // Deprovision implements the Provision interface.
 func (p *Provisioner) Deprovision(ctx context.Context) error {
-	app := p.generateApplication()
-
-	applicationProvisioner := application.New(p.client, app, labels.SelectorFromSet(p.getLabels()))
-
-	if err := applicationProvisioner.Deprovision(ctx); err != nil {
+	if err := application.New(p.client, p.generateApplication()).Deprovision(ctx); err != nil {
 		return err
 	}
 

--- a/pkg/util/retry/retry.go
+++ b/pkg/util/retry/retry.go
@@ -18,8 +18,15 @@ package retry
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
+)
+
+var (
+	// ErrNone is a sentinel for when no error is set by the callback
+	// and prevents a nil pointer dereference.
+	ErrNone = errors.New("no error")
 )
 
 // Callback is a callback that must return nil to escape the retry loop.
@@ -68,7 +75,7 @@ func (r *Retrier) DoWithContext(c context.Context, f Callback) error {
 	t := time.NewTicker(r.period)
 	defer t.Stop()
 
-	var rerr error
+	rerr := ErrNone
 
 	for {
 		select {


### PR DESCRIPTION
While the cluster is provisioning we need to, in parallel, create the remote cluster in ArgoCD and then install Cilium so the cluster application eventually becomes healthy.  The hope here is CoreDNS won't come up because CAPI doesn't provision a CNI, so we don't have to mess around with setting up taints.