### PR TITLE
Handle ArgoCD Workload Cluster Upsert

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Consult the [developer documentation](DEVELOPER.md) for local development instru
 Download the official binary (update the version as appropriate):
 
 ```shell
-wget -O ~/bin/unikornctl https://github.com/eschercloudai/unikorn/releases/download/0.1.0/unikornctl-linux-amd64
+wget -O ~/bin/unikornctl https://github.com/eschercloudai/unikorn/releases/download/0.2.0/unikornctl-linux-amd64
 ```
 
 Set up shell completion:
@@ -75,7 +75,7 @@ spec:
   source:
     path: charts/unikorn
     repoURL: git@github.com:eschercloudai/unikorn
-    targetRevision: v0.1.0
+    targetRevision: v0.2.0
   destination:
     namespace: unikorn
     server: https://kubernetes.default.svc

--- a/charts/unikorn/values.yaml
+++ b/charts/unikorn/values.yaml
@@ -5,7 +5,7 @@ repository: ghcr.io
 organization: eschercloudai
 
 # Set the global container tag.
-tag: 0.1.0
+tag: 0.2.0
 
 # Set the docker configuration, doing so will create a secret and link it
 # to the service accounts of all the controllers.  You can do something like:


### PR DESCRIPTION
While the kubeconfig may be available, you cannot add the cluster to ArgoCD until it's partially functional.  As such retry the addition until it actually succeeds. Also, this is looking good enough for a 0.2.0 release.