### PR TITLE
Support Workload Pool Add/Delete

### DIFF
--- a/pkg/apis/unikorn/v1alpha1/helpers.go
+++ b/pkg/apis/unikorn/v1alpha1/helpers.go
@@ -189,3 +189,12 @@ func (c *KubernetesCluster) UpdateCondition(t KubernetesClusterConditionType, st
 func (c *KubernetesCluster) UpdateAvailableCondition(status corev1.ConditionStatus, reason KubernetesClusterConditionReason, message string) bool {
 	return c.UpdateCondition(KubernetesClusterConditionAvailable, status, reason, message)
 }
+
+// GetName is the name passed down to Helm.
+func (w *KubernetesWorkloadPool) GetName() string {
+	if w.Spec.Name != nil {
+		return *w.Spec.Name
+	}
+
+	return w.Name
+}

--- a/pkg/cmd/create/create.go
+++ b/pkg/cmd/create/create.go
@@ -34,6 +34,7 @@ func NewCreateCommand(f cmdutil.Factory) *cobra.Command {
 		newCreateProjectCommand(f),
 		newCreateControlPlaneCommand(f),
 		newCreateClusterCommand(f),
+		newCreateWorkloadPoolCommand(f),
 	}
 
 	cmd.AddCommand(commands...)

--- a/pkg/cmd/create/create_workload_pool.go
+++ b/pkg/cmd/create/create_workload_pool.go
@@ -1,0 +1,206 @@
+/*
+Copyright 2022 EscherCloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package create
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+
+	"github.com/eschercloudai/unikorn/generated/clientset/unikorn"
+	unikornv1alpha1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
+	"github.com/eschercloudai/unikorn/pkg/cmd/errors"
+	"github.com/eschercloudai/unikorn/pkg/cmd/util"
+	"github.com/eschercloudai/unikorn/pkg/cmd/util/completion"
+	"github.com/eschercloudai/unikorn/pkg/constants"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	computil "k8s.io/kubectl/pkg/util/completion"
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+const (
+	defaultWorkloadReplicas = 3
+)
+
+// createWorkloadPoolOptions defines a set of options that are required to create
+// a cluster.
+type createWorkloadPoolOptions struct {
+	// project defines the project to create the cluster under.
+	project string
+
+	// controlPlane defines the control plane name that the cluster will
+	// be provisioned with.
+	controlPlane string
+
+	// cluster is the cluster name this belongs to.
+	cluster string
+
+	// cloud indicates the clouds.yaml key to use.  If only one exists it
+	// will default to that, otherwise it's a required parameter.
+	cloud string
+
+	// name is the name of the workload pool.
+	name string
+
+	// version defines the Kubernetes version to install.
+	version util.SemverFlag
+
+	// image defines the Openstack image for Kubernetes nodes.
+	image string
+
+	// flavor defines the Openstack VM flavor.
+	flavor string
+
+	// replicas defines the number of replicas (nodes).
+	replicas int
+
+	// diskSize defines the persistent volume size to provision with.
+	diskSize util.QuantityFlag
+
+	// availabilityZone defines in what Openstack failure domain the Kubernetes
+	// cluster will be provisioned in.
+	availabilityZone string
+
+	// client gives access to our custom resources.
+	client unikorn.Interface
+}
+
+// addFlags registers create cluster options flags with the specified cobra command.
+func (o *createWorkloadPoolOptions) addFlags(f cmdutil.Factory, cmd *cobra.Command) {
+	// Unikorn options.
+	util.RequiredStringVarWithCompletion(cmd, &o.project, "project", "", "Kubernetes project name that contains the control plane.", computil.ResourceNameCompletionFunc(f, unikornv1alpha1.ProjectResource))
+	util.RequiredStringVarWithCompletion(cmd, &o.controlPlane, "control-plane", "", "Control plane to provision the workload pool in.", completion.ControlPlanesCompletionFunc(f, &o.project))
+	util.RequiredStringVarWithCompletion(cmd, &o.cluster, "cluster", "", "Cluster to provision the workload pool for.", completion.ClustersCompletionFunc(f, &o.project, &o.controlPlane))
+
+	// Openstack configuration options.
+	util.StringVarWithCompletion(cmd, &o.cloud, "cloud", "", "Cloud config to use within clouds.yaml.", completion.CloudCompletionFunc)
+
+	// Kubernetes workload pool options.
+	util.RequiredVar(cmd, &o.version, "version", "Kubernetes version to deploy.  Provisioning will be faster if this matches the version preloaded on images defined by the --image flag.")
+	util.RequiredStringVarWithCompletion(cmd, &o.flavor, "flavor", "", "Kubernetes workload Openstack flavor (see: 'openstack flavor list'.)", completion.OpenstackFlavorCompletionFunc(&o.cloud))
+	cmd.Flags().IntVar(&o.replicas, "replicas", defaultWorkloadReplicas, "Number of workload replicas.")
+	util.RequiredStringVarWithCompletion(cmd, &o.image, "image", "", "Openstack image (see: 'openstack image list'.)", completion.OpenstackImageCompletionFunc(&o.cloud))
+	util.StringVarWithCompletion(cmd, &o.availabilityZone, "availability-zone", "", "Openstack availability zone to provision into. Will default to that specified for the control plane. (see: 'openstack availability zone list'.)", completion.OpenstackAvailabilityZoneCompletionFunc(&o.cloud))
+	cmd.Flags().Var(&o.diskSize, "disk-size", "Disk size, defaults to that of the machine flavor.")
+}
+
+// complete fills in any options not does automatically by flag parsing.
+func (o *createWorkloadPoolOptions) complete(f cmdutil.Factory, args []string) error {
+	config, err := f.ToRESTConfig()
+	if err != nil {
+		return err
+	}
+
+	if o.client, err = unikorn.NewForConfig(config); err != nil {
+		return err
+	}
+
+	if len(args) != 1 {
+		return errors.ErrIncorrectArgumentNum
+	}
+
+	o.name = args[0]
+
+	return nil
+}
+
+// validate validates any tainted input not handled by complete() or flags
+// processing.
+func (o *createWorkloadPoolOptions) validate() error {
+	return nil
+}
+
+// run executes the command.
+func (o *createWorkloadPoolOptions) run() error {
+	namespace, err := util.GetControlPlaneNamespace(context.TODO(), o.client, o.project, o.controlPlane)
+	if err != nil {
+		return err
+	}
+
+	version := unikornv1alpha1.SemanticVersion(o.version.Semver)
+
+	workloadPool := &unikornv1alpha1.KubernetesWorkloadPool{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: o.cluster + "-" + o.name,
+			Labels: map[string]string{
+				constants.VersionLabel:           constants.Version,
+				constants.ProjectLabel:           o.project,
+				constants.ControlPlaneLabel:      o.controlPlane,
+				constants.KubernetesClusterLabel: o.cluster,
+			},
+		},
+		Spec: unikornv1alpha1.KubernetesWorkloadPoolSpec{
+			Name: &o.name,
+			MachineGeneric: unikornv1alpha1.MachineGeneric{
+				Version:  &version,
+				Image:    &o.image,
+				Flavor:   &o.flavor,
+				Replicas: &o.replicas,
+				DiskSize: o.diskSize.Quantity,
+			},
+		},
+	}
+
+	if _, err := o.client.UnikornV1alpha1().KubernetesWorkloadPools(namespace).Create(context.TODO(), workloadPool, metav1.CreateOptions{}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+var (
+	//nolint:gochecknoglobals
+	createWorkloadPoolLong = templates.LongDesc(`
+	Create a Kubernetes cluster workload pool.
+
+	This command defines workload pools for a Kubernetes cluster.  You can define
+	pools before, or after creating a cluster.  The former will provision them
+	during control plane scale up and result in faster start-up times.  The latter
+	will provision the pools after the cluster is fully scaled and healthy.
+
+	The --cloud flag is optional, but it's recommended to set it to allow tab
+	completion on flavor and image parameters.`)
+
+	//nolint:gochecknoglobals
+	createWorkloadPoolExamples = util.TemplatedExample(`
+        # Create a Kubernetes cluster workload pool
+        {{.Application}} create workload-pool --project foo --control-plane bar --cluster foo --flavor g.medium_a100_MIG_2g.20gb --version v1.24.7 --image ubuntu-2004-kube-v1.24.7 baz`)
+)
+
+// newCreateWorkloadPoolCommand creates a command that is able to provison a new Kubernetes
+// cluster with a Cluster API control plane.
+func newCreateWorkloadPoolCommand(f cmdutil.Factory) *cobra.Command {
+	o := createWorkloadPoolOptions{}
+
+	cmd := &cobra.Command{
+		Use:     "workload-pool",
+		Short:   "Create a Kubernetes cluster workload pool",
+		Long:    createWorkloadPoolLong,
+		Example: createWorkloadPoolExamples,
+		Run: func(cmd *cobra.Command, args []string) {
+			util.AssertNilError(o.complete(f, args))
+			util.AssertNilError(o.validate())
+			util.AssertNilError(o.run())
+		},
+	}
+
+	o.addFlags(f, cmd)
+
+	return cmd
+}

--- a/pkg/cmd/util/flags.go
+++ b/pkg/cmd/util/flags.go
@@ -50,6 +50,15 @@ func RequiredStringVar(cmd *cobra.Command, p *string, name, value, usage string)
 	}
 }
 
+// StringVarWithCompletion registers a string flag with a completion function.
+func StringVarWithCompletion(cmd *cobra.Command, p *string, name, value, usage string, f func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective)) {
+	cmd.Flags().StringVar(p, name, value, usage)
+
+	if err := cmd.RegisterFlagCompletionFunc(name, f); err != nil {
+		panic(err)
+	}
+}
+
 // RequiredStringVarWithCompletion registers a string flag marked as required and
 // with a completion function.
 func RequiredStringVarWithCompletion(cmd *cobra.Command, p *string, name, value, usage string, f func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective)) {
@@ -102,7 +111,7 @@ func (s SemverFlag) Type() string {
 
 // QuantityFlag provides parsing and type checking of quanities.
 type QuantityFlag struct {
-	Quantity resource.Quantity
+	Quantity *resource.Quantity
 }
 
 // Ensure the pflag.Value interface is implemented.
@@ -110,6 +119,10 @@ var _ = pflag.Value(&QuantityFlag{})
 
 // String returns the current value.
 func (s QuantityFlag) String() string {
+	if s.Quantity == nil {
+		return ""
+	}
+
 	return s.Quantity.String()
 }
 
@@ -120,7 +133,7 @@ func (s *QuantityFlag) Set(in string) error {
 		return err
 	}
 
-	s.Quantity = quantity
+	s.Quantity = &quantity
 
 	return nil
 }

--- a/pkg/provisioners/clusterapi/provisioner.go
+++ b/pkg/provisioners/clusterapi/provisioner.go
@@ -125,6 +125,7 @@ func (p *Provisioner) generateCertManagerApplication() *unstructured.Unstructure
 				"syncPolicy": map[string]interface{}{
 					"automated": map[string]interface{}{
 						"selfHeal": true,
+						"prune":    true,
 					},
 					"syncOptions": []string{
 						"CreateNamespace=true",
@@ -184,6 +185,7 @@ func (p *Provisioner) generateClusterAPIApplication() *unstructured.Unstructured
 				"syncPolicy": map[string]interface{}{
 					"automated": map[string]interface{}{
 						"selfHeal": true,
+						"prune":    true,
 					},
 				},
 			},

--- a/pkg/provisioners/vcluster/provisioner.go
+++ b/pkg/provisioners/vcluster/provisioner.go
@@ -140,6 +140,7 @@ func (p *Provisioner) generateApplication() *unstructured.Unstructured {
 				"syncPolicy": map[string]interface{}{
 					"automated": map[string]interface{}{
 						"selfHeal": true,
+						"prune":    true,
 					},
 				},
 			},


### PR DESCRIPTION
Adds in a unikornctl command to allow creation of workload pools and separates this entirely from the cluster (which is nicer from a UX perspective).  In an attempt to clean up old pools, via pruning, it became apparent that CAPI does naughty things, like claiming ownership when it shouldn't, thus keeping the MDs alive.  As such, we need to manually detect and reap them.