### PR TITLE
Application Credentials and Bug Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,22 @@ For the more adventurous, you can add it to `/etc/bash_completion.d/` or whateve
 Is all done via Helm, which means we can also deploy using ArgoCD.
 As this is a private repository, we're keeping the charts private for now also, so you'll need to either checkout the correct branch for a local Helm installation, or imbue Argo with an access token to get access to the repository.
 
+Deploy argo (the release name is hard code, don't change it yet please):
+
+```
+helm repo add argo https://argoproj.github.io/argo-helm
+helm repo update
+helm install argocd argo/argo-cd -n argocd --create-namespace
+```
+
+To add the credentials go to `Settings`, `Repositories` and `Connect Repo`, then fill in:
+
+* Connection method: SSH
+* Name: `unikorn`
+* Project: `default`
+* Repository URL: `git@github.com:eschercloudai/unikorn`
+* SSH private key data: the contents of `~/.ssh/id\_blah`
+
 You can install using the local repo, or with CD:
 
 <details>
@@ -75,7 +91,11 @@ spec:
   source:
     path: charts/unikorn
     repoURL: git@github.com:eschercloudai/unikorn
-    targetRevision: v0.3.2
+    targetRevision: 0.3.3
+    helm:
+      parameters:
+      - name: dockerConfig
+        value: # run "cat ~/.docker/config.json | base64 -w0"
   destination:
     namespace: unikorn
     server: https://kubernetes.default.svc

--- a/README.release.md
+++ b/README.release.md
@@ -1,0 +1,7 @@
+# Cuttng a Release Checklist
+
+* Update the `README.md` file to reflect the new version.
+* Update the helm `Chart.yaml` to reflect the new version.
+* Commit and merge.
+* Tag the release `git tag x.y.z`
+* Push the tag `git push origin x.y.z`

--- a/charts/unikorn/Chart.yaml
+++ b/charts/unikorn/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for deploying Unikorn
 
 type: application
 
-version: 0.3.2
-appVersion: "0.3.2"
+version: 0.3.3
+appVersion: "0.3.3"
 
 icon: https://raw.githubusercontent.com/eschercloudai/unikorn/main/icons/default.png

--- a/charts/unikorn/values.yaml
+++ b/charts/unikorn/values.yaml
@@ -11,7 +11,7 @@ organization: eschercloudai
 
 # Set the docker configuration, doing so will create a secret and link it
 # to the service accounts of all the controllers.  You can do something like:
-# --set dockerConfig=$(cat ~/.docker/config.json | base64 -d)
+# --set dockerConfig=$(cat ~/.docker/config.json | base64 -w0)
 dockerConfig:
 
 # Set the image pull secret on the service accounts of all the controllers.

--- a/pkg/managers/cluster/reconcile.go
+++ b/pkg/managers/cluster/reconcile.go
@@ -59,12 +59,10 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	server := fmt.Sprintf("https://vcluster.%s", object.Namespace)
 
-	labels := map[string]string{
-		constants.ProjectLabel:      object.Labels[constants.ProjectLabel],
-		constants.ControlPlaneLabel: object.Labels[constants.ControlPlaneLabel],
+	provisioner, err := cluster.New(ctx, r.client, object, server)
+	if err != nil {
+		return reconcile.Result{}, err
 	}
-
-	provisioner := cluster.New(r.client, object, server).WithLabels(labels)
 
 	// If it's being deleted, ignore it, we don't need to take any additional action.
 	if object.DeletionTimestamp != nil {

--- a/pkg/provisioners/controlplane/provisioner.go
+++ b/pkg/provisioners/controlplane/provisioner.go
@@ -80,18 +80,6 @@ var _ provisioners.Provisioner = &Provisioner{}
 
 var ErrMissingLabel = errors.New("expected label is missing")
 
-func (p *Provisioner) controlPlaneLabels() (map[string]string, error) {
-	project, ok := p.controlPlane.Labels[constants.ProjectLabel]
-	if !ok {
-		return nil, ErrMissingLabel
-	}
-
-	return map[string]string{
-		constants.ProjectLabel:      project,
-		constants.ControlPlaneLabel: p.controlPlane.Name,
-	}, nil
-}
-
 // Provision implements the Provision interface.
 func (p *Provisioner) Provision(ctx context.Context) error {
 	log := log.FromContext(ctx)
@@ -106,7 +94,7 @@ func (p *Provisioner) Provision(ctx context.Context) error {
 		return err
 	}
 
-	labels, err := p.controlPlaneLabels()
+	labels, err := p.controlPlane.ResourceLabels()
 	if err != nil {
 		return err
 	}
@@ -218,7 +206,7 @@ func (p *Provisioner) Deprovision(ctx context.Context) error {
 		return err
 	}
 
-	labels, err := p.controlPlaneLabels()
+	labels, err := p.controlPlane.ResourceLabels()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Allows the consumption of application credentials from the clouds.yaml file along with the more standard password stuff.  Updates the docs to be more accurate and helpful, as I was forced to scrub and recreate.  On that note, things went very wrong when deploying multipl clusters which forced me to appraise a few things, one of which was the labels were totally wrong for clusters, so I guess the argo applications were aliasing.  I've made this much more resilient by moving them into the common API helpers code.  Also a bunch of segfaults occurred due another fix that handled no default worker pools I stupidly put off.