### PR TITLE
Autoscaling Fixes

### DIFF
--- a/charts/unikorn/crds/unikorn.eschercloud.ai_kubernetesclusters.yaml
+++ b/charts/unikorn/crds/unikorn.eschercloud.ai_kubernetesclusters.yaml
@@ -179,10 +179,6 @@ spec:
                       control plane will always be deployed in this region.  Individual
                       worload pools will default to this, but can override it.
                     type: string
-                  region:
-                    description: Region is the region that the cluster is provisioned
-                      in.
-                    type: string
                   sshKeyName:
                     description: SSHKeyName is the SSH key name to use to provide
                       access to the VMs.
@@ -193,8 +189,6 @@ spec:
                 - cloudConfig
                 - externalNetworkId
                 - failureDomain
-                - region
-                - sshKeyName
                 type: object
               timeout:
                 default: 20m

--- a/pkg/apis/unikorn/v1alpha1/types.go
+++ b/pkg/apis/unikorn/v1alpha1/types.go
@@ -514,9 +514,7 @@ type KubernetesClusterOpenstackSpec struct {
 	// to use for provisioning.
 	Cloud *string `json:"cloud"`
 	// SSHKeyName is the SSH key name to use to provide access to the VMs.
-	SSHKeyName *string `json:"sshKeyName"`
-	// Region is the region that the cluster is provisioned in.
-	Region *string `json:"region"`
+	SSHKeyName *string `json:"sshKeyName,omitempty"`
 	// FailureDomain is the global failure domain to use.  The control plane
 	// will always be deployed in this region.  Individual worload pools will
 	// default to this, but can override it.

--- a/pkg/apis/unikorn/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/unikorn/v1alpha1/zz_generated.deepcopy.go
@@ -417,11 +417,6 @@ func (in *KubernetesClusterOpenstackSpec) DeepCopyInto(out *KubernetesClusterOpe
 		*out = new(string)
 		**out = **in
 	}
-	if in.Region != nil {
-		in, out := &in.Region, &out.Region
-		*out = new(string)
-		**out = **in
-	}
 	if in.FailureDomain != nil {
 		in, out := &in.FailureDomain, &out.FailureDomain
 		*out = new(string)

--- a/pkg/cmd/create/create_cluster.go
+++ b/pkg/cmd/create/create_cluster.go
@@ -125,17 +125,11 @@ type createClusterOptions struct {
 	// diskSize defines the persistent volume size to provision with.
 	diskSize flags.QuantityFlag
 
-	// region is the OpenStack region the cluster exists in.
-	region string
-
 	// availabilityZone defines in what Openstack failure domain the Kubernetes
 	// cluster will be provisioned in.
 	availabilityZone string
 
 	// sshKeyName defines the SSH key to inject onto the Kubernetes cluster.
-	// TODO: this is a legacy thing, and a security hole.  I'm pretty sure
-	// cloud-init will do all the provisioning.  If we need access for support
-	// then there are better ways of achieving this.
 	sshKeyName string
 
 	// autoscaling allows the cluster to determine its own destiny, not the
@@ -170,9 +164,8 @@ func (o *createClusterOptions) addFlags(f cmdutil.Factory, cmd *cobra.Command) {
 
 	// Openstack provisioning options.
 	flags.RequiredStringVarWithCompletion(cmd, &o.image, "image", "", "Kubernetes Openstack image (see: 'openstack image list'.)", completion.OpenstackImageCompletionFunc(&o.cloud))
-	flags.RequiredStringVar(cmd, &o.region, "region", "", "Openstack region to provision into.")
 	flags.RequiredStringVarWithCompletion(cmd, &o.availabilityZone, "availability-zone", "", "Openstack availability zone to provision into.  Only one is supported currently (see: 'openstack availability zone list'.)", completion.OpenstackAvailabilityZoneCompletionFunc(&o.cloud))
-	flags.RequiredStringVarWithCompletion(cmd, &o.sshKeyName, "ssh-key-name", "", "Openstack SSH key to inject onto the Kubernetes nodes (see: 'openstack keypair list'.)", completion.OpenstackSSHKeyCompletionFunc(&o.cloud))
+	flags.StringVarWithCompletion(cmd, &o.sshKeyName, "ssh-key-name", "", "Openstack SSH key to inject onto the Kubernetes nodes (see: 'openstack keypair list'.)", completion.OpenstackSSHKeyCompletionFunc(&o.cloud))
 
 	// Feature enablement.
 	cmd.Flags().BoolVar(&o.autoscaling, "enable-autoscaling", false, "Enables cluster auto-scaling. To function, you must configure autoscaling on individual workload pools.")
@@ -287,7 +280,6 @@ func (o *createClusterOptions) run() error {
 				CACert:            &o.caCert,
 				CloudConfig:       &o.clouds,
 				Cloud:             &o.cloud,
-				Region:            &o.region,
 				FailureDomain:     &o.availabilityZone,
 				SSHKeyName:        &o.sshKeyName,
 				ExternalNetworkID: &o.externalNetworkID,
@@ -348,7 +340,7 @@ var (
 	//nolint:gochecknoglobals
 	createClusterExamples = util.TemplatedExample(`
         # Create a Kubernetes cluster
-        {{.Application}} create cluster --project foo --control-plane bar --cloud nl1-simon --ssh-key-name spjmurray --external-network c9d130bc-301d-45c0-9328-a6964af65579 --flavor c.small --version v1.24.7 --image ubuntu-2004-kube-v1.24.7 --availability-zone nova baz`)
+        {{.Application}} create cluster --project foo --control-plane bar --cloud nl1-simon --external-network c9d130bc-301d-45c0-9328-a6964af65579 --flavor c.small --version v1.24.7 --image ubuntu-2004-kube-v1.24.7 --availability-zone nova baz`)
 )
 
 // newCreateClusterCommand creates a command that is able to provison a new Kubernetes

--- a/pkg/provisioners/clusterapi/provisioner.go
+++ b/pkg/provisioners/clusterapi/provisioner.go
@@ -152,7 +152,7 @@ func (p *Provisioner) generateClusterAPIApplication() *unstructured.Unstructured
 					//TODO:  programmable
 					"repoURL":        "https://eschercloudai.github.io/helm-cluster-api",
 					"chart":          "cluster-api",
-					"targetRevision": "v0.1.1",
+					"targetRevision": "v0.1.3",
 				},
 				"destination": map[string]interface{}{
 					"name": p.server,
@@ -161,15 +161,6 @@ func (p *Provisioner) generateClusterAPIApplication() *unstructured.Unstructured
 					{
 						"group": "rbac.authorization.k8s.io",
 						"kind":  "ClusterRole",
-						"name":  "capi-aggregated-manager-role",
-						"jsonPointers": []interface{}{
-							"/rules",
-						},
-					},
-					{
-						"group": "rbac.authorization.k8s.io",
-						"kind":  "ClusterRole",
-						"name":  "capi-kubeadm-control-plane-aggregated-manager-role",
 						"jsonPointers": []interface{}{
 							"/rules",
 						},

--- a/pkg/util/retry/retry.go
+++ b/pkg/util/retry/retry.go
@@ -80,7 +80,7 @@ func (r *Retrier) DoWithContext(c context.Context, f Callback) error {
 	for {
 		select {
 		case <-c.Done():
-			return fmt.Errorf("%w: last error: %s", c.Err(), rerr.Error())
+			return fmt.Errorf("%s: %w", c.Err().Error(), rerr)
 		case <-t.C:
 			if rerr = f(); rerr != nil {
 				break


### PR DESCRIPTION
Remove namepsace scoped RBAC for the autoscaler as that's broken, and ignore the replicas field in machine deployments because cluster autoscaler updates the spec when it shouldn't. Additionally based on experience/feedback, remove the region as it's populated by the cloud controller or cloud config, make ssh keys optional, remove the default workload pool hack, update all the cluster api charts to pick up fixes and enable the above.  Finally fix an idempotency bug in the deprovisioning of clusters.