### PR TITLE
Make Remote Handling More Generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ spec:
   source:
     path: charts/unikorn
     repoURL: git@github.com:eschercloudai/unikorn
-    targetRevision: 0.3.3
+    targetRevision: 0.3.5
     helm:
       parameters:
       - name: dockerConfig

--- a/charts/unikorn/Chart.yaml
+++ b/charts/unikorn/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for deploying Unikorn
 
 type: application
 
-version: 0.3.4
-appVersion: "0.3.4"
+version: 0.3.5
+appVersion: "0.3.5"
 
 icon: https://raw.githubusercontent.com/eschercloudai/unikorn/main/icons/default.png

--- a/pkg/provisioners/cilium/provisioner.go
+++ b/pkg/provisioners/cilium/provisioner.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/eschercloudai/unikorn/pkg/provisioners"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/application"
+	"github.com/eschercloudai/unikorn/pkg/provisioners/remotecluster"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -40,16 +41,16 @@ type Provisioner struct {
 	// resource defines the unique resource this provisoner belongs to.
 	resource application.MutuallyExclusiveResource
 
-	// server is the ArgoCD server to provision in.
-	server string
+	// remote is the remote cluster to deploy to.
+	remote remotecluster.Generator
 }
 
 // New returns a new initialized provisioner object.
-func New(client client.Client, resource application.MutuallyExclusiveResource, server string) *Provisioner {
+func New(client client.Client, resource application.MutuallyExclusiveResource, remote remotecluster.Generator) *Provisioner {
 	return &Provisioner{
 		client:   client,
 		resource: resource,
-		server:   server,
+		remote:   remote,
 	}
 }
 
@@ -79,10 +80,6 @@ func (p *Provisioner) Generate() (client.Object, error) {
 					"chart":          "cilium",
 					"targetRevision": "1.12.4",
 				},
-				"destination": map[string]interface{}{
-					"name":      p.server,
-					"namespace": "kube-system",
-				},
 				"syncPolicy": map[string]interface{}{
 					"automated": map[string]interface{}{
 						"selfHeal": true,
@@ -98,7 +95,7 @@ func (p *Provisioner) Generate() (client.Object, error) {
 
 // Provision implements the Provision interface.
 func (p *Provisioner) Provision(ctx context.Context) error {
-	if err := application.New(p.client, p).Provision(ctx); err != nil {
+	if err := application.New(p.client, p).OnRemote(p.remote).InNamespace("kube-system").Provision(ctx); err != nil {
 		return err
 	}
 
@@ -107,7 +104,7 @@ func (p *Provisioner) Provision(ctx context.Context) error {
 
 // Deprovision implements the Provision interface.
 func (p *Provisioner) Deprovision(ctx context.Context) error {
-	if err := application.New(p.client, p).Deprovision(ctx); err != nil {
+	if err := application.New(p.client, p).OnRemote(p.remote).InNamespace("kube-system").Deprovision(ctx); err != nil {
 		return err
 	}
 

--- a/pkg/provisioners/clusterapi/provisioner.go
+++ b/pkg/provisioners/clusterapi/provisioner.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/eschercloudai/unikorn/pkg/provisioners"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/application"
+	"github.com/eschercloudai/unikorn/pkg/provisioners/remotecluster"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -41,16 +42,16 @@ type Provisioner struct {
 	// resource defines the unique resource this provisoner belongs to.
 	resource application.MutuallyExclusiveResource
 
-	// server is the server to deploy the application to.
-	server string
+	// remote is the remote cluster to deploy to.
+	remote remotecluster.Generator
 }
 
 // New returns a new initialized provisioner object.
-func New(client client.Client, resource application.MutuallyExclusiveResource, server string) *Provisioner {
+func New(client client.Client, resource application.MutuallyExclusiveResource, remote remotecluster.Generator) *Provisioner {
 	return &Provisioner{
 		client:   client,
 		resource: resource,
-		server:   server,
+		remote:   remote,
 	}
 }
 
@@ -79,9 +80,6 @@ func (p *Provisioner) Generate() (client.Object, error) {
 					"repoURL":        "https://eschercloudai.github.io/helm-cluster-api",
 					"chart":          "cluster-api",
 					"targetRevision": "v0.1.3",
-				},
-				"destination": map[string]interface{}{
-					"name": p.server,
 				},
 				"ignoreDifferences": []map[string]interface{}{
 					{
@@ -114,7 +112,7 @@ func (p *Provisioner) Generate() (client.Object, error) {
 
 // Provision implements the Provision interface.
 func (p *Provisioner) Provision(ctx context.Context) error {
-	if err := application.New(p.client, p).Provision(ctx); err != nil {
+	if err := application.New(p.client, p).OnRemote(p.remote).Provision(ctx); err != nil {
 		return err
 	}
 
@@ -123,7 +121,7 @@ func (p *Provisioner) Provision(ctx context.Context) error {
 
 // Deprovision implements the Provision interface.
 func (p *Provisioner) Deprovision(ctx context.Context) error {
-	if err := application.New(p.client, p).Deprovision(ctx); err != nil {
+	if err := application.New(p.client, p).OnRemote(p.remote).Deprovision(ctx); err != nil {
 		return err
 	}
 

--- a/pkg/provisioners/clusteropenstack/hack.go
+++ b/pkg/provisioners/clusteropenstack/hack.go
@@ -1,0 +1,246 @@
+/*
+Copyright 2022 EscherCloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusteropenstack
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/eschercloudai/unikorn/pkg/provisioners/vcluster"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// getWorkloadPoolMachineDeploymentNames gets a list of machine deployments that should
+// exist for this cluster.
+// TODO: this is horrific and relies on knowing the internal workings of the Helm chart
+// not just the public API!!!
+func (p *Provisioner) getWorkloadPoolMachineDeploymentNames() []string {
+	names := make([]string, len(p.workloadPools.Items))
+
+	for i, pool := range p.workloadPools.Items {
+		names[i] = fmt.Sprintf("%s-pool-%s", p.cluster.Name, pool.GetName())
+	}
+
+	return names
+}
+
+// filterOwnedResources removes any resources that aren't owned by the cluster.
+func (p *Provisioner) filterOwnedResources(resources []unstructured.Unstructured) []unstructured.Unstructured {
+	var filtered []unstructured.Unstructured
+
+	for _, resource := range resources {
+		ownerReferences := resource.GetOwnerReferences()
+
+		for _, ownerReference := range ownerReferences {
+			if ownerReference.Kind != "Cluster" || ownerReference.Name != p.cluster.Name {
+				continue
+			}
+
+			filtered = append(filtered, resource)
+		}
+	}
+
+	return filtered
+}
+
+// getOwnedResource returns resources of the specified API version/kind that belong
+// to the cluster.
+func (p *Provisioner) getOwnedResource(ctx context.Context, c client.Client, apiVersion, kind string) ([]unstructured.Unstructured, error) {
+	objects := &unstructured.UnstructuredList{
+		Object: map[string]interface{}{
+			"apiVersion": apiVersion,
+			"kind":       kind,
+		},
+	}
+
+	options := &client.ListOptions{
+		Namespace: p.cluster.Name,
+	}
+
+	if err := c.List(ctx, objects, options); err != nil {
+		return nil, err
+	}
+
+	return p.filterOwnedResources(objects.Items), nil
+}
+
+// getMachineDeployments gets all live machine deployments for the cluster.
+func (p *Provisioner) getMachineDeployments(ctx context.Context, c client.Client) ([]unstructured.Unstructured, error) {
+	// TODO: this is flaky as hell, due to hard coded versions, needs a fix upstream.
+	return p.getOwnedResource(ctx, c, "cluster.x-k8s.io/v1beta1", "MachineDeployment")
+}
+
+// getKubeadmConfigTemplates gets all live config templates for the cluster.
+func (p *Provisioner) getKubeadmConfigTemplates(ctx context.Context, c client.Client) ([]unstructured.Unstructured, error) {
+	// TODO: this is flaky as hell, due to hard coded versions, needs a fix upstream.
+	return p.getOwnedResource(ctx, c, "bootstrap.cluster.x-k8s.io/v1beta1", "KubeadmConfigTemplate")
+}
+
+// getKubeadmControlPlanes gets all live control planes for the cluster.
+func (p *Provisioner) getKubeadmControlPlanes(ctx context.Context, c client.Client) ([]unstructured.Unstructured, error) {
+	// TODO: this is flaky as hell, due to hard coded versions, needs a fix upstream.
+	return p.getOwnedResource(ctx, c, "controlplane.cluster.x-k8s.io/v1beta1", "KubeadmControlPlane")
+}
+
+// getOpenstackMachineTemplates gets all live machine templates for the cluster.
+func (p *Provisioner) getOpenstackMachineTemplates(ctx context.Context, c client.Client) ([]unstructured.Unstructured, error) {
+	// TODO: this is flaky as hell, due to hard coded versions, needs a fix upstream.
+	return p.getOwnedResource(ctx, c, "infrastructure.cluster.x-k8s.io/v1alpha5", "OpenStackMachineTemplate")
+}
+
+// resourceExistsUnstructured tells whether the resource exists in the
+// expected list of names.
+func resourceExistsUnstructured(o unstructured.Unstructured, names []string) bool {
+	for _, name := range names {
+		if name == o.GetName() {
+			return true
+		}
+	}
+
+	return false
+}
+
+// filterNamedResourcesUnstructured returns only the resources in the names list.
+func filterNamedResourcesUnstructured(objects []unstructured.Unstructured, names []string) []unstructured.Unstructured {
+	var filtered []unstructured.Unstructured
+
+	for _, o := range objects {
+		if resourceExistsUnstructured(o, names) {
+			filtered = append(filtered, o)
+		}
+	}
+
+	return filtered
+}
+
+// getExpectedKubeadmConfigTemplateNames extracts the expected config templates from the
+// deployment references.
+func getExpectedKubeadmConfigTemplateNames(deployments []unstructured.Unstructured) []string {
+	names := make([]string, len(deployments))
+
+	for i, deployment := range deployments {
+		// TODO: may be not ok.
+		names[i], _, _ = unstructured.NestedString(deployment.Object, "spec", "template", "spec", "bootstrap", "configRef", "name")
+	}
+
+	return names
+}
+
+// getExpectedOpenstackMachineTemplateNames extracts the expected machine templates from the
+// deployment references.
+func getExpectedOpenstackMachineTemplateNames(deployments []unstructured.Unstructured, controlPlanes []unstructured.Unstructured) []string {
+	//nolint: prealloc
+	var names []string
+
+	for _, deployment := range deployments {
+		// TODO: may be not ok.
+		name, _, _ := unstructured.NestedString(deployment.Object, "spec", "template", "spec", "infrastructureRef", "name")
+
+		names = append(names, name)
+	}
+
+	for _, controlPlane := range controlPlanes {
+		name, _, _ := unstructured.NestedString(controlPlane.Object, "spec", "machineTemplate", "infrastructureRef", "name")
+
+		names = append(names, name)
+	}
+
+	return names
+}
+
+// deleteForeignResources removes any resources in the given object set that
+// don't have a corresponding name in the allowed list.
+func deleteForeignResources(ctx context.Context, c client.Client, objects []unstructured.Unstructured, allowed []string) error {
+	log := log.FromContext(ctx)
+
+	for i, o := range objects {
+		if resourceExistsUnstructured(o, allowed) {
+			continue
+		}
+
+		log.Info("deleting orphaned resource", "kind", o.GetKind(), "name", o.GetName())
+
+		if err := c.Delete(ctx, &objects[i]); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// deleteOrphanedMachineDeployments does just that. So what happens when you
+// delete a workload pool is that the application notes it's no longer in the
+// manifest, BUT, and I like big buts, cluster-api has added an owner reference,
+// so Argo thinks it's an implicitly created resource now.  So, what we need to
+// do is manually delete any orphaned MachineDeployments.
+func (p *Provisioner) deleteOrphanedMachineDeployments(ctx context.Context) error {
+	vc := vcluster.NewControllerRuntimeClient(p.client)
+
+	vclusterClient, err := vc.Client(ctx, p.cluster.Namespace, false)
+	if err != nil {
+		return fmt.Errorf("%w: failed to create vcluster client", err)
+	}
+
+	deployments, err := p.getMachineDeployments(ctx, vclusterClient)
+	if err != nil {
+		return err
+	}
+
+	kubeadmConfigTemplates, err := p.getKubeadmConfigTemplates(ctx, vclusterClient)
+	if err != nil {
+		return err
+	}
+
+	kubeadmControlPlanes, err := p.getKubeadmControlPlanes(ctx, vclusterClient)
+	if err != nil {
+		return err
+	}
+
+	openstackMachineTemplates, err := p.getOpenstackMachineTemplates(ctx, vclusterClient)
+	if err != nil {
+		return err
+	}
+
+	// Work out the machine deployment names that should exist, grab all that
+	// exist, and remember the intersection.
+	deploymentNames := p.getWorkloadPoolMachineDeploymentNames()
+
+	expectedDeployments := filterNamedResourcesUnstructured(deployments, deploymentNames)
+
+	// Get the expected kubeadm config template and openstack machine template names from
+	// the deployments.  These are generated by Helm, and unguessable.
+	kubeadmConfigTemplatesNames := getExpectedKubeadmConfigTemplateNames(expectedDeployments)
+	openstackMachineTemplatesNames := getExpectedOpenstackMachineTemplateNames(expectedDeployments, kubeadmControlPlanes)
+
+	if err := deleteForeignResources(ctx, vclusterClient, deployments, deploymentNames); err != nil {
+		return err
+	}
+
+	if err := deleteForeignResources(ctx, vclusterClient, kubeadmConfigTemplates, kubeadmConfigTemplatesNames); err != nil {
+		return err
+	}
+
+	if err := deleteForeignResources(ctx, vclusterClient, openstackMachineTemplates, openstackMachineTemplatesNames); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/provisioners/clusteropenstack/remotecluster.go
+++ b/pkg/provisioners/clusteropenstack/remotecluster.go
@@ -18,8 +18,6 @@ package clusteropenstack
 
 import (
 	"context"
-	"fmt"
-	"strings"
 
 	"github.com/eschercloudai/unikorn/pkg/provisioners/remotecluster"
 	"github.com/eschercloudai/unikorn/pkg/util/retry"
@@ -62,13 +60,16 @@ func NewRemoteClusterGenerator(client client.Client, namespace, name string, lab
 
 // Name implements the remotecluster.Generator interface.
 func (g *RemoteClusterGenerator) Name() string {
-	name := fmt.Sprintf("kubernetes-%s", g.name)
+	return "kubernetes"
+}
 
-	if len(g.labels) != 0 {
-		name += ":" + strings.Join(g.labels, ":")
-	}
+// Labels mplements the remotecluster.Generator interface.
+func (g *RemoteClusterGenerator) Labels() []string {
+	labels := []string{g.name}
 
-	return name
+	labels = append(labels, g.labels...)
+
+	return labels
 }
 
 // Server implements the remotecluster.Generator interface.

--- a/pkg/provisioners/openstackcloudprovider/provisioner.go
+++ b/pkg/provisioners/openstackcloudprovider/provisioner.go
@@ -26,6 +26,7 @@ import (
 	unikornv1alpha1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
 	"github.com/eschercloudai/unikorn/pkg/provisioners"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/application"
+	"github.com/eschercloudai/unikorn/pkg/provisioners/remotecluster"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -52,16 +53,16 @@ type Provisioner struct {
 	// cluster is the Kubernetes cluster we're provisioning.
 	cluster *unikornv1alpha1.KubernetesCluster
 
-	// server is the ArgoCD server to provision in.
-	server string
+	// remote is the remote cluster to deploy to.
+	remote remotecluster.Generator
 }
 
 // New returns a new initialized provisioner object.
-func New(client client.Client, cluster *unikornv1alpha1.KubernetesCluster, server string) *Provisioner {
+func New(client client.Client, cluster *unikornv1alpha1.KubernetesCluster, remote remotecluster.Generator) *Provisioner {
 	return &Provisioner{
 		client:  client,
 		cluster: cluster,
-		server:  server,
+		remote:  remote,
 	}
 }
 
@@ -229,10 +230,6 @@ func (p *Provisioner) Generate() (client.Object, error) {
 						"values": string(values),
 					},
 				},
-				"destination": map[string]interface{}{
-					"name":      p.server,
-					"namespace": "ocp-system",
-				},
 				"syncPolicy": map[string]interface{}{
 					"automated": map[string]interface{}{
 						"selfHeal": true,
@@ -251,7 +248,7 @@ func (p *Provisioner) Generate() (client.Object, error) {
 
 // Provision implements the Provision interface.
 func (p *Provisioner) Provision(ctx context.Context) error {
-	if err := application.New(p.client, p).Provision(ctx); err != nil {
+	if err := application.New(p.client, p).OnRemote(p.remote).InNamespace("ocp-system").Provision(ctx); err != nil {
 		return err
 	}
 
@@ -260,7 +257,7 @@ func (p *Provisioner) Provision(ctx context.Context) error {
 
 // Deprovision implements the Provision interface.
 func (p *Provisioner) Deprovision(ctx context.Context) error {
-	if err := application.New(p.client, p).Deprovision(ctx); err != nil {
+	if err := application.New(p.client, p).OnRemote(p.remote).InNamespace("ocp-system").Deprovision(ctx); err != nil {
 		return err
 	}
 

--- a/pkg/provisioners/util.go
+++ b/pkg/provisioners/util.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2022 EscherCloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provisioners
+
+import (
+	unikornv1alpha1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
+	"github.com/eschercloudai/unikorn/pkg/constants"
+)
+
+// VClusterRemoteLabelsFromControlPlane extracts a unique set of labels from the
+// control plane for a remote vcluster.
+func VClusterRemoteLabelsFromControlPlane(controlPlane *unikornv1alpha1.ControlPlane) []string {
+	return []string{
+		controlPlane.Name,
+		controlPlane.Labels[constants.ProjectLabel],
+	}
+}
+
+// VClusterRemoteLabelsFromCluster extracts a unique set of labels from the
+// cluster for a remote vcluster.
+func VclusterRemoteLabelsFromCluster(cluster *unikornv1alpha1.KubernetesCluster) []string {
+	return []string{
+		cluster.Labels[constants.ControlPlaneLabel],
+		cluster.Labels[constants.ProjectLabel],
+	}
+}
+
+// ClusterOpenstackLabelsFromCluster extracts a unique set of labels from the cluster
+// for a remote kubernetes cluster.
+func ClusterOpenstackLabelsFromCluster(cluster *unikornv1alpha1.KubernetesCluster) []string {
+	return []string{
+		cluster.Labels[constants.ControlPlaneLabel],
+		cluster.Labels[constants.ProjectLabel],
+	}
+}

--- a/pkg/provisioners/vcluster/remotecluster.go
+++ b/pkg/provisioners/vcluster/remotecluster.go
@@ -19,7 +19,6 @@ package vcluster
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/eschercloudai/unikorn/pkg/provisioners/remotecluster"
 
@@ -55,13 +54,17 @@ func NewRemoteClusterGenerator(client client.Client, namespace string, labels []
 
 // Name implements the remotecluster.Generator interface.
 func (g *RemoteClusterGenerator) Name() string {
-	name := "vcluster-vcluster"
+	return "vcluster"
+}
 
-	if len(g.labels) != 0 {
-		name += ":" + strings.Join(g.labels, ":")
-	}
+// Labels mplements the remotecluster.Generator interface.
+func (g *RemoteClusterGenerator) Labels() []string {
+	// The instance name is implicit, for now.
+	labels := []string{"vcluster"}
 
-	return name
+	labels = append(labels, g.labels...)
+
+	return labels
 }
 
 // Server implements the remotecluster.Generator interface.


### PR DESCRIPTION
Refactor out destination knowledge from the application Genrerate functions and make it a genric function of the application itself.  In doing so we can propagate the remote generator down and benefit from whatever that gives us in the future.  Undid a couple changes to do with propagation of vcluster clients, it's adding in unnecessary coupling that looks ugly.