### PR TITLE
Jesus Saves!

### DIFF
--- a/pkg/provisioners/conditional/provisioner.go
+++ b/pkg/provisioners/conditional/provisioner.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2022 EscherCloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conditional
+
+import (
+	"context"
+
+	"github.com/eschercloudai/unikorn/pkg/provisioners"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+type Provisioner struct {
+	// Name is the conditional name.
+	Name string
+
+	// condition will execute the provisioner if true.
+	Condition func() bool
+
+	// Provisioner is the provisioner to provision.
+	Provisioner provisioners.Provisioner
+}
+
+// Ensure the Provisioner interface is implemented.
+var _ provisioners.Provisioner = &Provisioner{}
+
+// Provision implements the Provision interface.
+func (p *Provisioner) Provision(ctx context.Context) error {
+	log := log.FromContext(ctx)
+
+	if !p.Condition() {
+		log.Info("skipping conditional provision", "provisioner", p.Name)
+
+		return nil
+	}
+
+	return p.Provisioner.Provision(ctx)
+}
+
+// Deprovision implements the Provision interface.
+func (p *Provisioner) Deprovision(ctx context.Context) error {
+	log := log.FromContext(ctx)
+
+	if !p.Condition() {
+		log.Info("skipping conditional deprovision", "provisioner", p.Name)
+
+		return nil
+	}
+
+	return p.Provisioner.Deprovision(ctx)
+}

--- a/pkg/provisioners/serial/provisioner.go
+++ b/pkg/provisioners/serial/provisioner.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2022 EscherCloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package serial
+
+import (
+	"context"
+
+	"github.com/eschercloudai/unikorn/pkg/provisioners"
+)
+
+type Provisioner struct {
+	// Name is the conditional name.
+	Name string
+
+	// Provisioners are the provisioner to provision in order.
+	Provisioners []provisioners.Provisioner
+}
+
+// Ensure the Provisioner interface is implemented.
+var _ provisioners.Provisioner = &Provisioner{}
+
+// Provision implements the Provision interface.
+func (p *Provisioner) Provision(ctx context.Context) error {
+	for _, provisioner := range p.Provisioners {
+		if err := provisioner.Provision(ctx); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Deprovision implements the Provision interface.
+// Note: things happen in the reverse order to provisioning, this assumes
+// that the same code that generates the provisioner, generates the deprovisioner
+// and ordering constraints matter.
+func (p *Provisioner) Deprovision(ctx context.Context) error {
+	for i := range p.Provisioners {
+		provisioner := p.Provisioners[len(p.Provisioners)-1-i]
+
+		if err := provisioner.Deprovision(ctx); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
Finally... All of the refactoring work was building up to this.  Once everything has been implemented using the same interface, we can build generic primatives like conditional execution, serial grouping etc.  All of that leads to defining provisioners for complex things in a single statement.  Doing so allows a lot of repetetive boilerplate error handling to be done once, then shared as common code.  The end result is very inherently readable code.