### PR TITLE
Autoscale Fixes and Scale to Zero

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ spec:
   source:
     path: charts/unikorn
     repoURL: git@github.com:eschercloudai/unikorn
-    targetRevision: 0.3.6
+    targetRevision: 0.3.7
     helm:
       parameters:
       - name: dockerConfig

--- a/charts/unikorn/Chart.yaml
+++ b/charts/unikorn/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for deploying Unikorn
 
 type: application
 
-version: 0.3.6
-appVersion: "0.3.6"
+version: 0.3.7
+appVersion: "0.3.7"
 
 icon: https://raw.githubusercontent.com/eschercloudai/unikorn/main/icons/default.png

--- a/pkg/provisioners/clusteropenstack/provisioner.go
+++ b/pkg/provisioners/clusteropenstack/provisioner.go
@@ -298,23 +298,10 @@ func (p *Provisioner) Generate() (client.Object, error) {
 					//TODO:  programmable
 					"repoURL":        "https://eschercloudai.github.io/helm-cluster-api",
 					"chart":          "cluster-api-cluster-openstack",
-					"targetRevision": "v0.3.6",
+					"targetRevision": "v0.3.7",
 					"helm": map[string]interface{}{
 						"releaseName": p.cluster.Name,
 						"values":      string(values),
-					},
-				},
-				"ignoreDifferences": []interface{}{
-					// We use a JQ query to select machine deployments that
-					// have auto-scaling constraints on them.  If they do, then
-					// ignore the replicas field as the cluster autoscaler will
-					// update that and we don't want to revert it.
-					map[string]interface{}{
-						"group": "cluster.x-k8s.io/v1beta1",
-						"kind":  "MachineDeployments",
-						"jqPathExpressions": []interface{}{
-							`select(.metadata.annotations["capacity.cluster-autoscaler.kubernetes.io/cpu"] != null) | .spec.replicas`,
-						},
 					},
 				},
 				"syncPolicy": map[string]interface{}{


### PR DESCRIPTION
Use a new cluster helm chart that will not set the replicas at all when autoscaling is enabled, it transpires that CAPI erroneously sets the MD replicas when the scale subresource is updated, this collides with Argo which then reverts the change.  Classic split brain that they won't fix. Update the scheduling and toleratons for the nVidia GPU operator to move it off the workload pools, and therefore can scale to zero.