### PR TITLE
Support building images for arm64 as well as amd64

### DIFF
--- a/docker/unikorn-cluster-manager/Dockerfile
+++ b/docker/unikorn-cluster-manager/Dockerfile
@@ -1,8 +1,23 @@
-FROM scratch
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.19.1 as builder
 
-COPY bin/amd64-linux-gnu/unikorn-cluster-manager /
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+
+ARG MODULE
+ARG VERSION
+ARG REVISION
+
+WORKDIR /app/
+ADD . .
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath -ldflags \
+	'-X $(MODULE)/pkg/constants.Version=$(VERSION) -X $(MODULE)/pkg/constants.Revision=$(REVISION)' \
+	-o unikorn-cluster-manager cmd/unikorn-cluster-manager/main.go
+
+FROM --platform=${TARGETPLATFORM:-linux/amd64} scratch
+WORKDIR /app/
+COPY --from=builder /app/unikorn-cluster-manager /unikorn-cluster-manager
 COPY hack/passwd.nonroot /etc/passwd
-
 USER 1000
-
 ENTRYPOINT ["/unikorn-cluster-manager"]

--- a/docker/unikorn-control-plane-manager/Dockerfile
+++ b/docker/unikorn-control-plane-manager/Dockerfile
@@ -1,8 +1,23 @@
-FROM scratch
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.19.1 as builder
 
-COPY bin/amd64-linux-gnu/unikorn-control-plane-manager /
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+
+ARG MODULE
+ARG VERSION
+ARG REVISION
+
+WORKDIR /app/
+ADD . .
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath -ldflags \
+	'-X $(MODULE)/pkg/constants.Version=$(VERSION) -X $(MODULE)/pkg/constants.Revision=$(REVISION)' \
+	-o unikorn-control-plane-manager cmd/unikorn-control-plane-manager/main.go
+
+FROM --platform=${TARGETPLATFORM:-linux/amd64} scratch
+WORKDIR /app/
+COPY --from=builder /app/unikorn-control-plane-manager /unikorn-control-plane-manager
 COPY hack/passwd.nonroot /etc/passwd
-
 USER 1000
-
 ENTRYPOINT ["/unikorn-control-plane-manager"]

--- a/docker/unikorn-project-manager/Dockerfile
+++ b/docker/unikorn-project-manager/Dockerfile
@@ -1,8 +1,23 @@
-FROM scratch
+FROM --platform=${BUILDPLATFORM:-linux/amd64} golang:1.19.1 as builder
 
-COPY bin/amd64-linux-gnu/unikorn-project-manager /
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+ARG TARGETOS
+ARG TARGETARCH
+
+ARG MODULE
+ARG VERSION
+ARG REVISION
+
+WORKDIR /app/
+ADD . .
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -trimpath -ldflags \
+	'-X $(MODULE)/pkg/constants.Version=$(VERSION) -X $(MODULE)/pkg/constants.Revision=$(REVISION)' \
+	-o unikorn-project-manager cmd/unikorn-project-manager/main.go
+
+FROM --platform=${TARGETPLATFORM:-linux/amd64} scratch
+WORKDIR /app/
+COPY --from=builder /app/unikorn-project-manager /unikorn-project-manager
 COPY hack/passwd.nonroot /etc/passwd
-
 USER 1000
-
 ENTRYPOINT ["/unikorn-project-manager"]


### PR DESCRIPTION
Rejig how container images are built to leverage Docker's support for multi-platform builds.

For container images, use multi-stage builds to generate binaries appropiate for the target architecture.  When pushed to a container registry, Docker generates a manifest detailing the targets platforms available and clients automatically download the right one.

Images for testing locally have a discrete target that generates native artefacts suitable for loading into KinD (for example).