### PR TITLE
Use forked cluster-autoscaler Helm chart for SFZ support

### DIFF
--- a/pkg/provisioners/clusterautoscaler/provisioner.go
+++ b/pkg/provisioners/clusterautoscaler/provisioner.go
@@ -92,9 +92,9 @@ func (p *Provisioner) Generate() (client.Object, error) {
 				"project": "default",
 				"source": map[string]interface{}{
 					//TODO:  programmable
-					"repoURL":        "https://kubernetes.github.io/autoscaler",
-					"chart":          "cluster-autoscaler",
-					"targetRevision": "9.21.1",
+					"repoURL":        "https://github.com/yankcrime/autoscaler",
+					"path":           "charts/cluster-autoscaler",
+					"targetRevision": "openstack-sfz",
 					"helm": map[string]interface{}{
 						"parameters": []interface{}{
 							map[string]interface{}{
@@ -120,6 +120,10 @@ func (p *Provisioner) Generate() (client.Object, error) {
 							map[string]interface{}{
 								"name":  "extraArgs.scale-down-unneeded-time",
 								"value": "5m",
+							},
+							map[string]interface{}{
+								"name":  "image.tag",
+								"value": "v1.26.1",
 							},
 						},
 					},


### PR DESCRIPTION
For scale-from-zero to work, the Service Account needs some additional provider-specific permissions.  See
https://github.com/kubernetes/autoscaler/blob/master/cluster-autoscaler/cloudprovider/clusterapi/README.md#rbac-changes-for-scaling-from-zero for the background and details.

This PR updates the application definition to use our fork which includes the necessary patch for CAPO.