### PR TITLE
Add in Kubernetes API Configuration

### DIFF
--- a/pkg/provisioners/clusteropenstack/provisioner.go
+++ b/pkg/provisioners/clusteropenstack/provisioner.go
@@ -250,7 +250,6 @@ func (p *Provisioner) Generate() (client.Object, error) {
 	}
 
 	// TODO: generate types from the Helm values schema.
-	// TODO: add in API configuration.
 	valuesRaw := map[string]interface{}{
 		"openstack": openstackValues,
 		"cluster": map[string]interface{}{
@@ -280,6 +279,20 @@ func (p *Provisioner) Generate() (client.Object, error) {
 			},
 			"dnsNameservers": nameservers,
 		},
+	}
+
+	if p.cluster.Spec.API != nil {
+		apiValues := map[string]interface{}{}
+
+		if p.cluster.Spec.API.SubjectAlternativeNames != nil {
+			apiValues["certificateSANs"] = p.cluster.Spec.API.SubjectAlternativeNames
+		}
+
+		if p.cluster.Spec.API.AllowedPrefixes != nil {
+			apiValues["allowList"] = p.cluster.Spec.API.AllowedPrefixes
+		}
+
+		valuesRaw["api"] = apiValues
 	}
 
 	values, err := yaml.Marshal(valuesRaw)

--- a/pkg/util/flags/flags.go
+++ b/pkg/util/flags/flags.go
@@ -19,6 +19,7 @@ package flags
 import (
 	"errors"
 	"fmt"
+	"net"
 	"regexp"
 	"strings"
 	"time"
@@ -169,4 +170,37 @@ func (s *DurationFlag) Set(in string) error {
 // Type returns the human readable type information.
 func (s DurationFlag) Type() string {
 	return "duration"
+}
+
+// IPNetSliceFlag provides a way to accumulate IP networks.
+type IPNetSliceFlag struct {
+	IPNetworks []net.IPNet
+}
+
+// String returns the current value.
+func (s IPNetSliceFlag) String() string {
+	l := make([]string, len(s.IPNetworks))
+
+	for i, network := range s.IPNetworks {
+		l[i] = network.String()
+	}
+
+	return strings.Join(l, ",")
+}
+
+// Set sets the value and does any error checking.
+func (s *IPNetSliceFlag) Set(in string) error {
+	_, n, err := net.ParseCIDR(in)
+	if err != nil {
+		return err
+	}
+
+	s.IPNetworks = append(s.IPNetworks, *n)
+
+	return nil
+}
+
+// Type returns the human readable type information.
+func (s IPNetSliceFlag) Type() string {
+	return "ipNetwork"
 }


### PR DESCRIPTION
Now CAPO 0.7.0 is out, we can enable firewalling.  Also adds in X.509 SAN definition.