### PR TITLE
nit: Add 'control-planes' as an alias

### DIFF
--- a/pkg/cmd/aliases/aliases.go
+++ b/pkg/cmd/aliases/aliases.go
@@ -27,6 +27,7 @@ var (
 	// ControlPlane defines cobra aliases for "control-plane" commands.
 	//nolint:gochecknoglobals
 	ControlPlane = []string{
+		"control-planes",
 		"controlplanes",
 		"cp",
 	}


### PR DESCRIPTION
I'm forever typing the (in my head) pluralised version of the canonical alias 'control-plane', only to find it's not recognised.