### PR TITLE
Bump Cluster Chart Again

### DIFF
--- a/pkg/provisioners/clusteropenstack/provisioner.go
+++ b/pkg/provisioners/clusteropenstack/provisioner.go
@@ -368,7 +368,7 @@ func (p *Provisioner) Generate() (client.Object, error) {
 					//TODO:  programmable
 					"repoURL":        "https://eschercloudai.github.io/helm-cluster-api",
 					"chart":          "cluster-api-cluster-openstack",
-					"targetRevision": "v0.3.11",
+					"targetRevision": "v0.3.12",
 					"helm": map[string]interface{}{
 						"releaseName": p.cluster.Name,
 						"values":      string(values),


### PR DESCRIPTION
See that repo for an extended account of what's happened.  Basically 0.3.11 introduced a change that is impossible for CAPO to handle, so clusters provisioned prior to this are stuck unable to be reconciled by Argo.  Assume 0.3.11-0.3.12 are broken (though they aren't).