### PR TITLE
FIx Server Concurrency Bug

### DIFF
--- a/cmd/unikorn-server/main.go
+++ b/cmd/unikorn-server/main.go
@@ -149,7 +149,7 @@ func main() {
 		BaseRouter:       router,
 		ErrorHandlerFunc: handler.HandleError,
 		Middlewares: []generated.MiddlewareFunc{
-			middleware.NewOpenAPIValidator(authorizer).Middleware,
+			middleware.OpenAPIValidatorMiddlewareFactory(authorizer),
 		},
 	}
 

--- a/pkg/server/middleware/openapi.go
+++ b/pkg/server/middleware/openapi.go
@@ -45,9 +45,10 @@ type OpenAPIValidator struct {
 var _ http.Handler = &OpenAPIValidator{}
 
 // NewOpenAPIValidator returns an initialized validator middleware.
-func NewOpenAPIValidator(authorizer *Authorizer) *OpenAPIValidator {
+func NewOpenAPIValidator(authorizer *Authorizer, next http.Handler) *OpenAPIValidator {
 	return &OpenAPIValidator{
 		authorizer: authorizer,
+		next:       next,
 	}
 }
 
@@ -176,9 +177,10 @@ func (v *OpenAPIValidator) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// Middleware performs any authorization handling middleware.
-func (v *OpenAPIValidator) Middleware(next http.Handler) http.Handler {
-	v.next = next
-
-	return v
+// OpenAPIValidatorMiddlewareFactory returns a function that generates per-request
+// middleware functions.
+func OpenAPIValidatorMiddlewareFactory(authorizer *Authorizer) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return NewOpenAPIValidator(authorizer, next)
+	}
 }


### PR DESCRIPTION
Infuriating bug which made me think my ES6 skills were clearly borken, when it was the underlying server.  Stupidly when creating validating middlewares I was using the same instance, just with an updated next handler.  Obviusly doing this with multiple requests in flight resulted in them all calling the same handler.  Ensure each handler gets a new middleware each time.