### PR TITLE
Caching Part 1

### DIFF
--- a/charts/unikorn/templates/unikorn-server.yaml
+++ b/charts/unikorn/templates/unikorn-server.yaml
@@ -40,6 +40,8 @@ rules:
   - services
   verbs:
   - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Unbeknownst to me the controller-runtime already has a caching client that routes get/list through a cache, which means we don't poll the API all the time, and just have a chunked encoding stream, win!  While here we need a context, so may as well wire that up to a signal hander for graceful shutdown of the server.