### PR TITLE
Make Server List Output Stable

### DIFF
--- a/pkg/apis/unikorn/v1alpha1/helpers.go
+++ b/pkg/apis/unikorn/v1alpha1/helpers.go
@@ -19,6 +19,8 @@ package v1alpha1
 import (
 	"errors"
 	"net"
+	"sort"
+	"strings"
 
 	"github.com/eschercloudai/unikorn/pkg/constants"
 
@@ -259,4 +261,49 @@ func (w *KubernetesWorkloadPool) GetName() string {
 	}
 
 	return w.Name
+}
+
+// Ensure type is sortable for stable deterministic output.
+var _ sort.Interface = &ProjectList{}
+
+func (l ProjectList) Len() int {
+	return len(l.Items)
+}
+
+func (l ProjectList) Less(i, j int) bool {
+	return strings.Compare(l.Items[i].Name, l.Items[j].Name) == -1
+}
+
+func (l ProjectList) Swap(i, j int) {
+	l.Items[i], l.Items[j] = l.Items[j], l.Items[i]
+}
+
+// Ensure type is sortable for stable deterministic output.
+var _ sort.Interface = &ControlPlaneList{}
+
+func (l ControlPlaneList) Len() int {
+	return len(l.Items)
+}
+
+func (l ControlPlaneList) Less(i, j int) bool {
+	return strings.Compare(l.Items[i].Name, l.Items[j].Name) == -1
+}
+
+func (l ControlPlaneList) Swap(i, j int) {
+	l.Items[i], l.Items[j] = l.Items[j], l.Items[i]
+}
+
+// Ensure type is sortable for stable deterministic output.
+var _ sort.Interface = &KubernetesClusterList{}
+
+func (l KubernetesClusterList) Len() int {
+	return len(l.Items)
+}
+
+func (l KubernetesClusterList) Less(i, j int) bool {
+	return strings.Compare(l.Items[i].Name, l.Items[j].Name) == -1
+}
+
+func (l KubernetesClusterList) Swap(i, j int) {
+	l.Items[i], l.Items[j] = l.Items[j], l.Items[i]
 }

--- a/pkg/server/handler/cluster/client.go
+++ b/pkg/server/handler/cluster/client.go
@@ -19,6 +19,7 @@ package cluster
 import (
 	"context"
 	"net/http"
+	"sort"
 
 	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/vcluster"
@@ -67,6 +68,8 @@ func (c *Client) List(ctx context.Context, controlPlaneName generated.ControlPla
 	if err := c.client.List(ctx, result, &client.ListOptions{Namespace: controlPlane.Namespace}); err != nil {
 		return nil, errors.OAuth2ServerError("failed to list control planes").WithError(err)
 	}
+
+	sort.Stable(result)
 
 	return convertList(result), nil
 }

--- a/pkg/server/handler/controlplane/client.go
+++ b/pkg/server/handler/controlplane/client.go
@@ -18,6 +18,7 @@ package controlplane
 
 import (
 	"context"
+	"sort"
 
 	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
 	"github.com/eschercloudai/unikorn/pkg/constants"
@@ -153,6 +154,8 @@ func (c *Client) List(ctx context.Context) ([]*generated.ControlPlane, error) {
 	if err := c.client.List(ctx, result, &client.ListOptions{Namespace: project.Namespace}); err != nil {
 		return nil, errors.OAuth2ServerError("failed to list control planes").WithError(err)
 	}
+
+	sort.Stable(result)
 
 	return convertList(result), nil
 }


### PR DESCRIPTION
The UI elements tend to jump about because the caching is based on a map, so the iteration order is non-deterministic.  Add the sort.Interface to the list types and sort th eserver output.