### PR TITLE
Add Basic ACME/Cloudflare Stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ spec:
 
 #### Installing Unikorn
 
+**NOTE**: Unikorn Server is not installed by default, see below for details.
+
 You can install using the local repo, or with CD.
 
 First, unless you are doing local development and want to manually load images, you will want to configure image pull secrets in order to be able to pull the images.
@@ -208,7 +210,7 @@ spec:
   source:
     path: charts/unikorn
     repoURL: git@github.com:eschercloudai/unikorn
-    targetRevision: 0.3.15
+    targetRevision: 0.3.16
     helm:
       parameters:
       - name: dockerConfig
@@ -225,8 +227,43 @@ spec:
 ```
 </details>
 
-**Note:** Unikorn server is not installed by default.
+#### Installing Unikorn Server
+
 To enable it add the parameter `--set server.enabled=true`.
+This will install a developer version of the server with a self-signed certificate.
+
+Rudimentary support exists for ACME certificates using the DNS01 protocol.
+Only Cloudflare has been implemented and tested.
+
+A typical `values.yaml` that uses ACME could look like:
+
+```yaml
+server:
+  enabled: true
+  host: kubernetes.my-domain.com
+  acme:
+    email: spam@my-domain.com
+    server: https://acme-v02.api.letsencrypt.org/directory
+    cloudflare:
+      email: cloudflare-user@my-domain.com
+      apiToken: bW92ZV9hbG9uZ19jbGV2ZXJfZGljaw==
+```
+
+The host defines the X.509 SAN, and indeed the host the Ingress will respond to.
+There is no automated DDNS yet, so you will need to manually add the A record when the ingress comes up.
+
+The server shown is the production server, and will be trusted by browsers.
+You can use the `acme-staging-v02` host if just playing around as it's not as badly rate limited.
+
+Finally the API token you will need to configure to allow editing of records in your domain.
+It's base64 encoded e.g. `echo -n MY_TOKEN | base64 -w0`.
+
+#### Installing Unikorn UI
+
+To enable Unikorn UI `--set ui.enabled=true`.
+This only enables the ingress route for now.
+You will also need to install the UI using Helm as described in the [unikorn-ui repository](https://github.com/eschercloudai/unikorn-ui).
+It **must** be installed in the same namespace as Unikorn server in order for the service to be seen by the Ingress.
 
 ## Monitoring & Logging
 

--- a/charts/unikorn/Chart.yaml
+++ b/charts/unikorn/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for deploying Unikorn
 
 type: application
 
-version: 0.3.15
-appVersion: 0.3.15
+version: 0.3.16
+appVersion: 0.3.16
 
 icon: https://raw.githubusercontent.com/eschercloudai/unikorn/main/icons/default.png

--- a/charts/unikorn/templates/unikorn-server.yaml
+++ b/charts/unikorn/templates/unikorn-server.yaml
@@ -156,35 +156,43 @@ spec:
   - name: prometheus
     port: 8080
     targetPort: prometheus
+{{- if (and .Values.server.acme .Values.server.acme.cloudflare) }}
 ---
-# TODO: Use ACME for production releases.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: unikorn-server-ingress-cloudflare-api-token
+  labels:
+    {{- include "unikorn.labels" . | nindent 4 }}
+data:
+  token: {{ .Values.server.acme.cloudflare.apiToken }}
+{{- end }}
+---
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: unikorn-server-ingress
+  labels:
+    {{- include "unikorn.labels" . | nindent 4 }}
 spec:
+{{- if .Values.server.acme }}
+  acme:
+    email: {{ .Values.server.acme.email }}
+    server: {{ .Values.server.acme.server }}
+    privateKeySecretRef:
+      name: unikorn-server-ingress-acme-key
+    solvers:
+    - dns01:
+      {{- with $solver := .Values.server.acme.cloudflare }}
+        cloudflare:
+          email: {{ $solver.email }}
+          apiTokenSecretRef:
+            name: unikorn-server-ingress-cloudflare-api-token
+            key: token
+      {{- end }}
+{{- else }}
   selfSigned: {}
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: unikorn-server-ingress-ca
-spec:
-  isCA: true
-  commonName: unikorn-server-ingress-ca
-  secretName: unikorn-server-ingress-ca-tls
-  issuerRef:
-    group: cert-manager.io
-    kind: Issuer
-    name: unikorn-server-ingress
----
-apiVersion: cert-manager.io/v1
-kind: Issuer
-metadata:
-  name: unikorn-server-ingress-ca
-spec:
-  ca:
-    secretName: unikorn-server-ingress-ca-tls
+{{- end }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -193,7 +201,7 @@ metadata:
   labels:
     {{- include "unikorn.labels" . | nindent 4 }}
   annotations:
-    cert-manager.io/issuer: unikorn-server-ingress-ca
+    cert-manager.io/issuer: unikorn-server-ingress
 spec:
   ingressClassName: {{ .Values.server.ingressClass }}
   # For development you will want to add these names to /etc/hosts for the ingress

--- a/charts/unikorn/values.yaml
+++ b/charts/unikorn/values.yaml
@@ -51,6 +51,22 @@ server:
   # Sets the OTLP endpoint for shipping spans.
   # otlpEndpoint: jaeger-collector.default:4318
 
+  # Handles TLS issuance.  If not specified, this will use self-signed certs.
+  # acme:
+  #   # Email address of the TLS certificate contact.
+  #   email: spjmurray@yahoo.co.uk
+  #
+  #   # Server to generate the certificate/key pair.
+  #   server: https://acme-staging-v02.api.letsencrypt.org/directory
+  #
+  #   # Cloudflare defines a DNS01 solver.
+  #   cloudflare:
+  #     # Cloudflare user ID.
+  #     email: spjmurray@yahoo.co.uk
+  #
+  #     Cloudflare API token, base64 encoded e.g. $(cat ~/my-token | base64 -w0)
+  #     apiToken:
+
   # Allow configuration of application credentials.
   applicationCredentials:
     # Sets the roles to grant to credentials.  It is up to the Openstack administrator


### PR DESCRIPTION
Automation for certificate issue and rotation with Let's Encrypt using Cloudflare as a DNS01 service.