### PR TITLE
Handle annotations for server Ingress resource

### DIFF
--- a/charts/unikorn/templates/unikorn-server.yaml
+++ b/charts/unikorn/templates/unikorn-server.yaml
@@ -156,19 +156,7 @@ spec:
   - name: prometheus
     port: 8080
     targetPort: prometheus
-{{- if .Values.server.acme }}
-  {{- if .Values.server.acme.cloudflare }}
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: unikorn-server-ingress-cloudflare-api-token
-  labels:
-    {{- include "unikorn.labels" . | nindent 4 }}
-data:
-  token: {{ .Values.server.acme.cloudflare.apiToken }}
-  {{- end }}
-{{- end }}
+{{- if (not .Values.server.ingress.annotations) }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Issuer
@@ -177,22 +165,6 @@ metadata:
   labels:
     {{- include "unikorn.labels" . | nindent 4 }}
 spec:
-{{- if .Values.server.acme }}
-  acme:
-    email: {{ .Values.server.acme.email }}
-    server: {{ .Values.server.acme.server }}
-    privateKeySecretRef:
-      name: unikorn-server-ingress-acme-key
-    solvers:
-    - dns01:
-      {{- with $solver := .Values.server.acme.cloudflare }}
-        cloudflare:
-          email: {{ $solver.email }}
-          apiTokenSecretRef:
-            name: unikorn-server-ingress-cloudflare-api-token
-            key: token
-      {{- end }}
-{{- else }}
   selfSigned: {}
 {{- end }}
 ---
@@ -203,14 +175,18 @@ metadata:
   labels:
     {{- include "unikorn.labels" . | nindent 4 }}
   annotations:
-    cert-manager.io/issuer: unikorn-server-ingress
+  {{- if .Values.server.ingress.annotations }}
+  {{ toYaml .Values.server.ingress.annotations | indent 2 }}
+  {{- else }}
+    cert-manager.io/issuer: "unikorn-server-ingress"
+  {{- end }}
 spec:
-  ingressClassName: {{ .Values.server.ingressClass }}
+  ingressClassName: {{ .Values.server.ingress.ingressClass }}
   # For development you will want to add these names to /etc/hosts for the ingress
   # endpoint address.
   tls:
   - hosts:
-    - {{ .Values.server.host }}
+    - {{ .Values.server.ingress.host }}
     secretName: unikorn-server-ingress-tls
   rules:
   # The the UI is written as a JAMstack application, so the API is accessed via

--- a/charts/unikorn/values.yaml
+++ b/charts/unikorn/values.yaml
@@ -42,30 +42,17 @@ server:
   # Allows override of the global default image.
   image:
 
-  # Sets the ingress class to use.
-  ingressClass: nginx
+  ingress:
+    # Sets the ingress class to use.
+    ingressClass: nginx
 
-  # Sets the DNS hosts/X.509 Certs.
-  host: kubernetes.eschercloud.com
+    annotations: {}
+
+    # Sets the DNS hosts/X.509 Certs.
+    host: kubernetes.eschercloud.com
 
   # Sets the OTLP endpoint for shipping spans.
   # otlpEndpoint: jaeger-collector.default:4318
-
-  # Handles TLS issuance.  If not specified, this will use self-signed certs.
-  # acme:
-  #   # Email address of the TLS certificate contact.
-  #   email: spjmurray@yahoo.co.uk
-  #
-  #   # Server to generate the certificate/key pair.
-  #   server: https://acme-staging-v02.api.letsencrypt.org/directory
-  #
-  #   # Cloudflare defines a DNS01 solver.
-  #   cloudflare:
-  #     # Cloudflare user ID.
-  #     email: spjmurray@yahoo.co.uk
-  #
-  #     Cloudflare API token, base64 encoded e.g. $(cat ~/my-token | base64 -w0)
-  #     apiToken:
 
   # Allow configuration of application credentials.
   applicationCredentials:


### PR DESCRIPTION
Allow specifying annotations for the Ingress resource that's created for use by the Server component.  Useful if, for example, someone wants to specify the use of a ClusterIssuer that's defined elsewhere in order to provide TLS certificate issuance, or if additional annotations are required for components such as ExternalDNS.