### PR TITLE
Add A Manual Upgrade

### DIFF
--- a/charts/unikorn/templates/applicationbundles.yaml
+++ b/charts/unikorn/templates/applicationbundles.yaml
@@ -22,6 +22,27 @@ spec:
 apiVersion: unikorn.eschercloud.ai/v1alpha1
 kind: ApplicationBundle
 metadata:
+  name: control-plane-1.0.1
+spec:
+  kind: ControlPlane
+  version: 1.0.0
+  applications:
+  - name: vcluster
+    reference:
+      kind: HelmApplication
+      name: vcluster-0.12.1-1
+  - name: cert-manager
+    reference:
+      kind: HelmApplication
+      name: cert-manager-1.10.1-1
+  - name: cluster-api
+    reference:
+      kind: HelmApplication
+      name: cluster-api-0.1.6-1
+---
+apiVersion: unikorn.eschercloud.ai/v1alpha1
+kind: ApplicationBundle
+metadata:
   name: kubernetes-cluster-1.0.0
 spec:
   kind: KubernetesCluster

--- a/charts/unikorn/templates/applications.yaml
+++ b/charts/unikorn/templates/applications.yaml
@@ -22,6 +22,7 @@ spec:
   version: 0.12.1
   release: vcluster
 ---
+# This version (0.7.0) had an availability zone scheduling bug.
 apiVersion: unikorn.eschercloud.ai/v1alpha1
 kind: HelmApplication
 metadata:
@@ -34,6 +35,16 @@ spec:
   parameters:
   - name: cluster-api-provider-openstack.image
     value: spjmurray/capi-openstack-controller:v0.7.0-simon1
+---
+apiVersion: unikorn.eschercloud.ai/v1alpha1
+kind: HelmApplication
+metadata:
+  name: cluster-api-0.1.6-1
+spec:
+  repo: https://eschercloudai.github.io/helm-cluster-api
+  chart: cluster-api
+  version: v0.1.6
+  interface: 1.0.0
 ---
 apiVersion: unikorn.eschercloud.ai/v1alpha1
 kind: HelmApplication
@@ -71,7 +82,7 @@ kind: HelmApplication
 metadata:
   name: nvidia-gpu-operator-22.9.1-1
 spec:
-  repo: https://helm.ngc.nvidia.com/nvidi
+  repo: https://helm.ngc.nvidia.com/nvidia
   chart: gpu-operator
   version: v22.9.1
   interface: 1.0.0


### PR DESCRIPTION
CAPO 0.7.1 came out, so I can remove spjmurray from the code base! Listening yankcrime??  That means I can define a new CP bundle referencing the new application, and perform manaual upgrades, placing us in a perfect position for next week's automation of this task, and UI wizziness.