### PR TITLE
Non-Blocking Provisioner

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -8,7 +8,7 @@ on:
 env:
   GO_VERSION: 1.19.1
 jobs:
-  License:
+  Static:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -17,9 +17,13 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: ${{ env.GO_VERSION }}
+    - name: Touch
+      run: make touch
     - name: License Checker
       run: make license
-  Lint:
+    - name: Validate OpenAPI Schema
+      run: make touch validate
+  Runtime:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -30,30 +34,12 @@ jobs:
         go-version: ${{ env.GO_VERSION }}
     - name: Install Helm
       uses: azure/setup-helm@v3
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Touch
+      run: make touch
     - name: Golang CI/Helm Lint
-      run: make touch lint
-  Validate:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Setup Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: ${{ env.GO_VERSION }}
-    - name: Validate OpenAPI Schema
-      run: make touch validate
-  Build:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-    - name: Setup Go
-      uses: actions/setup-go@v3
-      with:
-        go-version: ${{ env.GO_VERSION }}
-    - name: Build All
-      run: make touch all
+      run: make lint
     - name: Build Images
       run: make images
     - name: Generated Code Checked In

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/deepmap/oapi-codegen v1.12.4
-	github.com/eschercloudai/argocd-client-go v0.0.0-20221208104342-581c85485ec5
+	github.com/eschercloudai/argocd-client-go v0.0.0-20230310111928-80edec6b0b46
 	github.com/getkin/kin-openapi v0.114.0
 	github.com/go-chi/chi/v5 v5.0.8
 	github.com/go-logr/logr v1.2.3

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,8 @@ github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/eschercloudai/argocd-client-go v0.0.0-20221208104342-581c85485ec5 h1:hEa4j7WHD6Sy/XYsW70vm39vDSGGJaoh4LzfKcWca34=
 github.com/eschercloudai/argocd-client-go v0.0.0-20221208104342-581c85485ec5/go.mod h1:nFOYyzot8oprUZS1DyPiIN9/2/sJTnU3VD5A3Hf7Vqg=
+github.com/eschercloudai/argocd-client-go v0.0.0-20230310111928-80edec6b0b46 h1:T0d6XFaRzGEUvy7ge2ggzepBe+4NirDukDA1bK7+t9A=
+github.com/eschercloudai/argocd-client-go v0.0.0-20230310111928-80edec6b0b46/go.mod h1:nFOYyzot8oprUZS1DyPiIN9/2/sJTnU3VD5A3Hf7Vqg=
 github.com/evanphx/json-patch v0.5.2/go.mod h1:ZWS5hhDbVDyob71nXKNL0+PWn6ToqBHMikGIFbs31qQ=
 github.com/evanphx/json-patch v5.6.0+incompatible h1:jBYDEEiFBPxA0v50tFdvOzQQTCvpL6mnFh5mB2/l16U=
 github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"time"
 )
 
 var (
@@ -71,4 +72,9 @@ const (
 
 	// NvidiaGPUType is used to indicate the GPU type for cluster-autoscaler.
 	NvidiaGPUType = "nvidia.com/gpu"
+
+	// DefaultYieldTimeout allows N seconds for a provisioner to do its thing
+	// and report a healthy status before yielding and giving someone else
+	// a go.
+	DefaultYieldTimeout = 10 * time.Second
 )

--- a/pkg/managers/cluster/reconcile.go
+++ b/pkg/managers/cluster/reconcile.go
@@ -24,6 +24,7 @@ import (
 
 	unikornv1alpha1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
 	"github.com/eschercloudai/unikorn/pkg/constants"
+	provisionererrors "github.com/eschercloudai/unikorn/pkg/provisioners/errors"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/managers/cluster"
 
 	corev1 "k8s.io/api/core/v1"
@@ -105,6 +106,17 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	defer cancel()
 
 	if err := provisioner.Provision(provisionContext); err != nil {
+		// If the provisioner has voluntarily yielded, requeue it and look at
+		// it later to allow others to use the worker, or indeed pickup delete
+		// requests, updates... probably not a great idea :D
+		// NOTE: DO NOT do what CAPI do and not-specify a wait period, it will
+		// suffer from an exponential back-off and kill performance.
+		if errors.Is(err, provisionererrors.ErrYield) {
+			log.Info("reconcile yielding")
+
+			return reconcile.Result{RequeueAfter: constants.DefaultYieldTimeout}, nil
+		}
+
 		if err := r.handleReconcileError(ctx, object, err); err != nil {
 			return reconcile.Result{}, err
 		}

--- a/pkg/provisioners/errors/errors.go
+++ b/pkg/provisioners/errors/errors.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2022-2023 EscherCloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import (
+	"errors"
+)
+
+var (
+	// ErrYield is raised when a provision/deprovision optation could
+	// block for a long time, in particular the bits that wait for apllication
+	// available status.  This will trigger a controller to requeue the request.
+	// The key things are that workers are unblocked, allowing other reconciles
+	// to be triggered, and we can pick up an modifications (e.g. the cluster is
+	// gubbed - thanks CAPO - and we can delete it without waiting for 10m as the
+	// case used to be in the old world.
+	ErrYield = errors.New("controller timeout yield")
+)

--- a/pkg/provisioners/helmapplications/clusteropenstack/provisioner.go
+++ b/pkg/provisioners/helmapplications/clusteropenstack/provisioner.go
@@ -373,8 +373,10 @@ func (p *Provisioner) Provision(ctx context.Context) error {
 	// TODO: this application is special in that everything it creates is a
 	// CRD, so as far as Argo is concerned, everything is healthy and the
 	// check passes instantly, rather than waiting for the CAPI controllers
-	// to do something.  We kinda fudge it due to the concurrent deployment
-	// of the CNI and cloud controller add-ons blocking.
+	// to do something.  What happens is the task that provisions the Argo
+	// remote cluster will yield, and second time around this will be in
+	// the Progressing state.  If we had a job for the Helm chart that ran
+	// until CAPI did something, that would add in the correct semantics.
 	if err := p.getProvisioner().Provision(ctx); err != nil {
 		return err
 	}

--- a/pkg/util/retry/retry.go
+++ b/pkg/util/retry/retry.go
@@ -80,7 +80,12 @@ func (r *Retrier) DoWithContext(c context.Context, f Callback) error {
 	for {
 		select {
 		case <-c.Done():
-			return fmt.Errorf("%s: %w", c.Err().Error(), rerr)
+			// NOTE: we wrap the context error here, knowing it's a timeout
+			// is more important than the last callback error, because of
+			// reconcile yielding code.  If this becomes a problem, we may
+			// need to define our own "expired" error type, that can wrap
+			// the underlying error.
+			return fmt.Errorf("%w: %s", c.Err(), rerr)
 		case <-t.C:
 			if rerr = f(); rerr != nil {
 				break


### PR DESCRIPTION
Change provisioning so that it's completely non-blocking, which is easy because it's totally idempotent already.  There are a couple places where we expect to wait:

* App provisioning
* Remote provisioning

We raise a special error when these are encountered, and cause the reconcile to requeue.  Quite simple really!