### PR TITLE
Fix HTTP Header Exposure

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ spec:
   source:
     path: charts/unikorn
     repoURL: git@github.com:eschercloudai/unikorn
-    targetRevision: 0.3.18
+    targetRevision: 0.3.19
     helm:
       parameters:
       - name: dockerConfig

--- a/charts/unikorn/Chart.yaml
+++ b/charts/unikorn/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for deploying Unikorn
 
 type: application
 
-version: 0.3.18
-appVersion: 0.3.18
+version: 0.3.19
+appVersion: 0.3.19
 
 icon: https://raw.githubusercontent.com/eschercloudai/unikorn/main/icons/default.png


### PR DESCRIPTION
Sadly OTEL doesn't do any security filtering, we should do this, so ensure the Authorization header doesn't get exfilterated from the system into logs.  Also the logging needs a little love after the infamous otel library "upgrade".