### PR TITLE
Disable NVIDIA validator workload

### DIFF
--- a/charts/unikorn/templates/applications.yaml
+++ b/charts/unikorn/templates/applications.yaml
@@ -135,10 +135,13 @@ kind: HelmApplication
 metadata:
   name: nvidia-gpu-operator-22.9.2-1
 spec:
-  repo: https://helm.ngc.nvidia.com/nvidia
   chart: gpu-operator
-  version: v22.9.2
   interface: 1.0.0
+  repo: https://helm.ngc.nvidia.com/nvidia
+  version: v22.9.2
+  parameters:
+  - name: validator.plugin
+    value: "null"
 ---
 apiVersion: unikorn.eschercloud.ai/v1alpha1
 kind: HelmApplication


### PR DESCRIPTION
Disable the workload part of the validator service, this avoiding the possibility for resource contention under certain scenarios.