### PR TITLE
Enable Go Caching for Release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,6 +18,7 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: ${{ env.GO_VERSION }}
+        cache: true
     - name: Docker Login
       uses: docker/login-action@v2
       with:


### PR DESCRIPTION
May as well speed up this process, the docker bits should be fairly quick, so this is the bottleneck.