### PR TITLE
Filter Images on Digital Signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ spec:
   source:
     path: charts/unikorn
     repoURL: git@github.com:eschercloudai/unikorn
-    targetRevision: 0.3.21
+    targetRevision: 0.3.22
     helm:
       parameters:
       - name: dockerConfig

--- a/charts/unikorn/Chart.yaml
+++ b/charts/unikorn/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for deploying Unikorn
 
 type: application
 
-version: 0.3.21
-appVersion: 0.3.21
+version: 0.3.22
+appVersion: 0.3.22
 
 icon: https://raw.githubusercontent.com/eschercloudai/unikorn/main/icons/default.png

--- a/charts/unikorn/templates/unikorn-server.yaml
+++ b/charts/unikorn/templates/unikorn-server.yaml
@@ -110,6 +110,7 @@ spec:
       - name: unikorn-server
         image: {{ include "unikorn.serverImage" . }}
         args:
+        - --image-signing-key={{ .Values.server.imageSigningKey }}
         {{- with $credentials := .Values.server.applicationCredentials -}}
           {{- with $roles := $credentials.roles -}}
             {{ printf "- --application-credential-roles=%s" (join "," $roles) | nindent 8 }}

--- a/charts/unikorn/values.yaml
+++ b/charts/unikorn/values.yaml
@@ -70,6 +70,12 @@ server:
     - member
     - load-balancer_member
 
+  # imageSigningKey allows the ESCDA key to be set and images to be filtered based
+  # on signature.
+  # TODO: this is only temporary, we'd probably expect this to come from a secret
+  # managed by vault.
+  imageSigningKey: LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUhZd0VBWUhLb1pJemowQ0FRWUZLNEVFQUNJRFlnQUVmOGs4RVY1TUg4M1BncThYd0JGUTd5YkU2NTEzRlh0awpHaG1jalp4WmYzbU5QOE0vb3VBbE0vZHdYWGpFeXZTNlJhVHdoT3A0aTdHL3VvbE5ZL0RJSCt1elc2VXNxR3VHClFpSW11Tm9BdzFSS1NQcEtyNWlJVXU2eEc1cDR3U3E5Ci0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQo=
+
 # UI that works with the server.
 ui:
   # Temporarily block deployment until it's complete.

--- a/pkg/cmd/util/completion/openstack.go
+++ b/pkg/cmd/util/completion/openstack.go
@@ -131,7 +131,7 @@ func OpenstackImageCompletionFunc(cloud *string) func(*cobra.Command, []string, 
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		results, err := client.Images(context.Background())
+		results, err := client.Images(context.Background(), nil)
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}

--- a/pkg/server/handler/cluster/client.go
+++ b/pkg/server/handler/cluster/client.go
@@ -27,6 +27,7 @@ import (
 	"github.com/eschercloudai/unikorn/pkg/server/errors"
 	"github.com/eschercloudai/unikorn/pkg/server/generated"
 	"github.com/eschercloudai/unikorn/pkg/server/handler/controlplane"
+	"github.com/eschercloudai/unikorn/pkg/server/handler/providers/openstack"
 
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -45,14 +46,17 @@ type Client struct {
 
 	// authenticator provides access to authentication services.
 	authenticator *authorization.Authenticator
+
+	openstack *openstack.Openstack
 }
 
 // NewClient returns a new client with required parameters.
-func NewClient(client client.Client, request *http.Request, authenticator *authorization.Authenticator) *Client {
+func NewClient(client client.Client, request *http.Request, authenticator *authorization.Authenticator, openstack *openstack.Openstack) *Client {
 	return &Client{
 		client:        client,
 		request:       request,
 		authenticator: authenticator,
+		openstack:     openstack,
 	}
 }
 

--- a/pkg/server/handler/cluster/conversion.go
+++ b/pkg/server/handler/cluster/conversion.go
@@ -29,7 +29,6 @@ import (
 	"github.com/eschercloudai/unikorn/pkg/server/generated"
 	"github.com/eschercloudai/unikorn/pkg/server/handler/applicationbundle"
 	"github.com/eschercloudai/unikorn/pkg/server/handler/controlplane"
-	"github.com/eschercloudai/unikorn/pkg/server/handler/providers/openstack"
 	"github.com/eschercloudai/unikorn/pkg/util"
 
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -352,14 +351,8 @@ func createAPI(options *generated.KubernetesCluster) (*unikornv1.KubernetesClust
 
 // createMachineGeneric creates a generic machine part of the cluster.
 func (c *Client) createMachineGeneric(m *generated.OpenstackMachinePool) (*unikornv1.MachineGeneric, *generated.OpenstackFlavor, error) {
-	// TODO: propagate client down.
-	client, err := openstack.New(c.authenticator)
-	if err != nil {
-		return nil, nil, errors.OAuth2ServerError("failed to create client").WithError(err)
-	}
-
 	// Check the image passed in is valid.
-	image, err := client.GetImage(c.request, m.ImageName)
+	image, err := c.openstack.GetImage(c.request, m.ImageName)
 	if err != nil {
 		if errors.IsHTTPNotFound(err) {
 			return nil, nil, errors.OAuth2InvalidRequest("invalid image").WithError(err)
@@ -375,7 +368,7 @@ func (c *Client) createMachineGeneric(m *generated.OpenstackMachinePool) (*uniko
 	}
 
 	// Check the flavor is valid
-	flavor, err := client.GetFlavor(c.request, m.FlavorName)
+	flavor, err := c.openstack.GetFlavor(c.request, m.FlavorName)
 	if err != nil {
 		if errors.IsHTTPNotFound(err) {
 			return nil, nil, errors.OAuth2InvalidRequest("invalid flavor").WithError(err)

--- a/pkg/server/handler/handler.go
+++ b/pkg/server/handler/handler.go
@@ -50,7 +50,7 @@ type Handler struct {
 }
 
 func New(client client.Client, authenticator *authorization.Authenticator, options *Options) (*Handler, error) {
-	o, err := openstack.New(authenticator)
+	o, err := openstack.New(options.openstack, authenticator)
 	if err != nil {
 		return nil, err
 	}
@@ -211,7 +211,7 @@ func (h *Handler) PutApiV1ControlplanesControlPlaneName(w http.ResponseWriter, r
 }
 
 func (h *Handler) GetApiV1ControlplanesControlPlaneNameClusters(w http.ResponseWriter, r *http.Request, controlPlaneName generated.ControlPlaneNameParameter) {
-	result, err := cluster.NewClient(h.client, r, h.authenticator).List(r.Context(), controlPlaneName)
+	result, err := cluster.NewClient(h.client, r, h.authenticator, h.openstack).List(r.Context(), controlPlaneName)
 	if err != nil {
 		errors.HandleError(w, r, err)
 		return
@@ -229,7 +229,7 @@ func (h *Handler) PostApiV1ControlplanesControlPlaneNameClusters(w http.Response
 		return
 	}
 
-	if err := cluster.NewClient(h.client, r, h.authenticator).Create(r.Context(), controlPlaneName, request); err != nil {
+	if err := cluster.NewClient(h.client, r, h.authenticator, h.openstack).Create(r.Context(), controlPlaneName, request); err != nil {
 		errors.HandleError(w, r, err)
 		return
 	}
@@ -239,7 +239,7 @@ func (h *Handler) PostApiV1ControlplanesControlPlaneNameClusters(w http.Response
 }
 
 func (h *Handler) DeleteApiV1ControlplanesControlPlaneNameClustersClusterName(w http.ResponseWriter, r *http.Request, controlPlaneName generated.ControlPlaneNameParameter, clusterName generated.ClusterNameParameter) {
-	if err := cluster.NewClient(h.client, r, h.authenticator).Delete(r.Context(), controlPlaneName, clusterName); err != nil {
+	if err := cluster.NewClient(h.client, r, h.authenticator, h.openstack).Delete(r.Context(), controlPlaneName, clusterName); err != nil {
 		errors.HandleError(w, r, err)
 		return
 	}
@@ -249,7 +249,7 @@ func (h *Handler) DeleteApiV1ControlplanesControlPlaneNameClustersClusterName(w 
 }
 
 func (h *Handler) GetApiV1ControlplanesControlPlaneNameClustersClusterName(w http.ResponseWriter, r *http.Request, controlPlaneName generated.ControlPlaneNameParameter, clusterName generated.ClusterNameParameter) {
-	result, err := cluster.NewClient(h.client, r, h.authenticator).Get(r.Context(), controlPlaneName, clusterName)
+	result, err := cluster.NewClient(h.client, r, h.authenticator, h.openstack).Get(r.Context(), controlPlaneName, clusterName)
 	if err != nil {
 		errors.HandleError(w, r, err)
 		return
@@ -267,7 +267,7 @@ func (h *Handler) PutApiV1ControlplanesControlPlaneNameClustersClusterName(w htt
 		return
 	}
 
-	if err := cluster.NewClient(h.client, r, h.authenticator).Update(r.Context(), controlPlaneName, clusterName, request); err != nil {
+	if err := cluster.NewClient(h.client, r, h.authenticator, h.openstack).Update(r.Context(), controlPlaneName, clusterName, request); err != nil {
 		errors.HandleError(w, r, err)
 		return
 	}
@@ -277,7 +277,7 @@ func (h *Handler) PutApiV1ControlplanesControlPlaneNameClustersClusterName(w htt
 }
 
 func (h *Handler) GetApiV1ControlplanesControlPlaneNameClustersClusterNameKubeconfig(w http.ResponseWriter, r *http.Request, controlPlaneName generated.ControlPlaneNameParameter, clusterName generated.ClusterNameParameter) {
-	result, err := cluster.NewClient(h.client, r, h.authenticator).GetKubeconfig(r.Context(), controlPlaneName, clusterName)
+	result, err := cluster.NewClient(h.client, r, h.authenticator, h.openstack).GetKubeconfig(r.Context(), controlPlaneName, clusterName)
 	if err != nil {
 		errors.HandleError(w, r, err)
 		return

--- a/pkg/server/handler/options.go
+++ b/pkg/server/handler/options.go
@@ -20,6 +20,8 @@ import (
 	"time"
 
 	"github.com/spf13/pflag"
+
+	"github.com/eschercloudai/unikorn/pkg/server/handler/providers/openstack"
 )
 
 // Options defines configurable handler options.
@@ -31,10 +33,15 @@ type Options struct {
 	// cacheMaxAge defines the max age for cachable items e.g. images and
 	// flavors don't change all that often.
 	cacheMaxAge time.Duration
+
+	openstack *openstack.Options
 }
 
 // AddFlags adds the options flags to the given flag set.
 func (o *Options) AddFlags(f *pflag.FlagSet) {
 	f.StringSliceVar(&o.applicationCredentialRoles, "application-credential-roles", nil, "A role to be added to application credentials on creation.  May be specified more than once.")
 	f.DurationVar(&o.cacheMaxAge, "cache-max-age", 24*time.Hour, "How long to cache long-lived queries in the browser.")
+
+	o.openstack = &openstack.Options{}
+	o.openstack.AddFlags(f)
 }

--- a/pkg/server/handler/providers/openstack/openstack.go
+++ b/pkg/server/handler/providers/openstack/openstack.go
@@ -34,6 +34,8 @@ import (
 
 // Openstack provides an HTTP handler for Openstack resources.
 type Openstack struct {
+	options *Options
+
 	endpoint string
 
 	// Cache clients as that's quite expensive.
@@ -44,7 +46,7 @@ type Openstack struct {
 }
 
 // New returns a new initialized Openstack handler.
-func New(authenticator *authorization.Authenticator) (*Openstack, error) {
+func New(options *Options, authenticator *authorization.Authenticator) (*Openstack, error) {
 	identityClientCache, err := lru.New[string, *openstack.IdentityClient](1024)
 	if err != nil {
 		return nil, err
@@ -66,6 +68,7 @@ func New(authenticator *authorization.Authenticator) (*Openstack, error) {
 	}
 
 	o := &Openstack{
+		options:                 options,
 		endpoint:                authenticator.Endpoint(),
 		identityClientCache:     identityClientCache,
 		computeClientCache:      computeClientCache,
@@ -340,7 +343,7 @@ func (o *Openstack) ListImages(r *http.Request) (generated.OpenstackImages, erro
 		return nil, errors.OAuth2ServerError("failed get compute client").WithError(err)
 	}
 
-	result, err := client.Images(r.Context())
+	result, err := client.Images(r.Context(), o.options.key.key)
 	if err != nil {
 		return nil, errors.OAuth2ServerError("failed list images").WithError(err)
 	}

--- a/pkg/server/handler/providers/openstack/options.go
+++ b/pkg/server/handler/providers/openstack/options.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2022-2023 EscherCloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openstack
+
+import (
+	"crypto/ecdsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"errors"
+	"fmt"
+
+	"github.com/spf13/pflag"
+)
+
+var (
+	// ErrPEMDecode is raised when the PEM decode failed for some reason.
+	ErrPEMDecode = errors.New("PEM decode error")
+
+	// ErrPEMType is raised when the encounter the wrong PEM type, e.g. PKCS#1.
+	ErrPEMType = errors.New("PEM type unsupported")
+
+	// ErrKeyType is raised when we encounter an unsupported key type.
+	ErrKeyType = errors.New("key type unsupported")
+)
+
+// PublicKeyVar contains a public key.
+type PublicKeyVar struct {
+	key *ecdsa.PublicKey
+}
+
+// Set accepts a base64 encoded PEM public key and tries to decode it.
+func (v *PublicKeyVar) Set(s string) error {
+	pemString, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return err
+	}
+
+	pemBlock, _ := pem.Decode(pemString)
+	if pemBlock == nil {
+		return ErrPEMDecode
+	}
+
+	if pemBlock.Type != "PUBLIC KEY" {
+		return fmt.Errorf("%w: %s", ErrPEMType, pemBlock.Type)
+	}
+
+	key, err := x509.ParsePKIXPublicKey(pemBlock.Bytes)
+	if err != nil {
+		return err
+	}
+
+	ecKey, ok := key.(*ecdsa.PublicKey)
+	if !ok {
+		return ErrKeyType
+	}
+
+	v.key = ecKey
+
+	return nil
+}
+
+func (v *PublicKeyVar) String() string {
+	return ""
+}
+
+func (v *PublicKeyVar) Type() string {
+	return "publickey"
+}
+
+type Options struct {
+	key PublicKeyVar
+}
+
+func (o *Options) AddFlags(f *pflag.FlagSet) {
+	f.Var(&o.key, "image-signing-key", "Key used to verify valid images for use with the platform")
+}


### PR DESCRIPTION
Now we only accept digital signatures for images, so we know they've come explicitly from Baski (unless the private key got exposed).  That way we protect ourselves from users impersonating valid images.