### PR TITLE
Bunp Cluster Chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ spec:
   source:
     path: charts/unikorn
     repoURL: git@github.com:eschercloudai/unikorn
-    targetRevision: 0.3.22
+    targetRevision: 0.3.23
     helm:
       parameters:
       - name: dockerConfig

--- a/charts/unikorn/Chart.yaml
+++ b/charts/unikorn/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for deploying Unikorn
 
 type: application
 
-version: 0.3.22
-appVersion: 0.3.22
+version: 0.3.23
+appVersion: 0.3.23
 
 icon: https://raw.githubusercontent.com/eschercloudai/unikorn/main/icons/default.png

--- a/charts/unikorn/templates/applicationbundles.yaml
+++ b/charts/unikorn/templates/applicationbundles.yaml
@@ -82,7 +82,7 @@ spec:
   - name: cluster-openstack
     reference:
       kind: HelmApplication
-      name: cluster-openstack-0.3.12-1
+      name: cluster-openstack-0.3.13-1
   - name: cilium
     reference:
       kind: HelmApplication

--- a/charts/unikorn/templates/applications.yaml
+++ b/charts/unikorn/templates/applications.yaml
@@ -83,6 +83,17 @@ spec:
 apiVersion: unikorn.eschercloud.ai/v1alpha1
 kind: HelmApplication
 metadata:
+  name: cluster-openstack-0.3.13-1
+spec:
+  repo: https://eschercloudai.github.io/helm-cluster-api
+  chart: cluster-api-cluster-openstack
+  version: v0.3.13
+  createNamespace: true
+  interface: 1.0.0
+---
+apiVersion: unikorn.eschercloud.ai/v1alpha1
+kind: HelmApplication
+metadata:
   name: openstack-cloud-provider-1.4.0-1
 spec:
   repo: https://kubernetes.github.io/cloud-provider-openstack

--- a/pkg/provisioners/application/provisioner.go
+++ b/pkg/provisioners/application/provisioner.go
@@ -449,6 +449,10 @@ func (p *Provisioner) Deprovision(ctx context.Context) error {
 	temp := resource.DeepCopy()
 	temp.SetFinalizers([]string{"resources-finalizer.argocd.argoproj.io"})
 
+	// Try to work around a race during deletion as per
+	// https://github.com/argoproj/argo-cd/issues/12943
+	unstructured.RemoveNestedField(temp.Object, "spec", "syncPolicy", "automated")
+
 	if err := p.client.Patch(ctx, temp, client.MergeFrom(resource)); err != nil {
 		return err
 	}


### PR DESCRIPTION
Fixes a race condition we trigger with CAPO deleting its machines and infrastructure at the same time.  In this case the openstackcluster gets killed and CAPO cannot deprovision the machines.  What this does is provisions cluster and MDs last, so they get deleted first, and in theory this problem doesn't happen.  However Argo is broken and appears to schedule a refecsh during delete, so to mitigate, turn of auto sync on deletion.