### PR TITLE
Add Default Time Window

### DIFF
--- a/pkg/monitor/upgrade/controlplane/check.go
+++ b/pkg/monitor/upgrade/controlplane/check.go
@@ -24,6 +24,7 @@ import (
 	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
 	"github.com/eschercloudai/unikorn/pkg/constants"
 	"github.com/eschercloudai/unikorn/pkg/monitor/upgrade/errors"
+	"github.com/eschercloudai/unikorn/pkg/monitor/upgrade/util"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -39,6 +40,7 @@ func New(client client.Client) *Checker {
 	}
 }
 
+//nolint:cyclop
 func (c *Checker) Check(ctx context.Context) error {
 	log := log.FromContext(ctx)
 
@@ -94,7 +96,14 @@ func (c *Checker) Check(ctx context.Context) error {
 			continue
 		}
 
-		// TODO: upgrade time windows.
+		// Is it allowed to happen now?  Base it on the UID for ultimate randomness,
+		// you can cause a stampede if all the resources are called "default".
+		window := util.GenerateTimeWindow(string(resource.UID))
+		if !window.In() {
+			log.Info("not in upgrade window, ignoring", "project", resource.Labels[constants.ProjectLabel], "controlplane", resource.Name, "start", window.Start, "end", window.End)
+			continue
+		}
+
 		log.Info("bundle upgrading", "project", resource.Labels[constants.ProjectLabel], "controlplane", resource.Name, "from", *bundle.Spec.Version, "to", *upgradeTarget.Spec.Version)
 	}
 

--- a/pkg/monitor/upgrade/util/timewindow.go
+++ b/pkg/monitor/upgrade/util/timewindow.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2022-2023 EscherCloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"crypto/sha256"
+	"time"
+)
+
+type TimeWindow struct {
+	Start time.Time
+	End   time.Time
+}
+
+// GenerateTimeWindow returns a one hour time window in which to trigger a
+// resource upgrade.  It's based on hashing to get a fairly uniform
+// distribution over time, so as to avoid everything getting done at
+// once... and the consequences when stuff goes wrong!
+func GenerateTimeWindow(name string) *TimeWindow {
+	sum := sha256.Sum256([]byte(name))
+
+	// So, counter to what's intuative, allow this to run
+	// Sunday-Thursday, so we're in normal working hours to
+	// fix any problems.
+	dayOfTheWeek := int(sum[0]) % 5
+
+	// Then stagger upgrades between 00:00 and 7:00 UTC, that
+	// gets most things out of the way before 8:00 CET (+01:00),
+	// or 08:00/09:00 respectively when BST/CEST kicks in.
+	hourOfTheDay := int(sum[1]) % 8
+
+	now := time.Now()
+
+	// Now here's where things get kinda complex... start by rounding down
+	// the current time to the previous/current Sunday, then add on our selected day.
+	// Golang's weekdays are indexed from zero, and if it ends up negative, the library
+	// will do the right thing.
+	day := now.Day() - int(now.Weekday()) + dayOfTheWeek
+
+	// Problematically, as with all things time related, it's not constant, in the
+	// sense that days may miss an hour, or have the same hour twice.  But, what the
+	// hell it'll upgrade next week, right?
+	start := time.Date(now.Year(), now.Month(), day, hourOfTheDay, 0, 0, 0, time.UTC)
+
+	return &TimeWindow{Start: start, End: start.Add(time.Hour)}
+}
+
+// In tells us if we are in the time window.
+func (t *TimeWindow) In() bool {
+	now := time.Now()
+
+	return now.After(t.Start) && now.Before(t.End)
+}

--- a/pkg/monitor/upgrade/util/timewindow_test.go
+++ b/pkg/monitor/upgrade/util/timewindow_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2022-2023 EscherCloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util_test
+
+import (
+	"fmt"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/eschercloudai/unikorn/pkg/monitor/upgrade/util"
+)
+
+const (
+	samples = 1000000
+)
+
+func logStats(t *testing.T, freqs map[int]int) {
+	t.Helper()
+
+	var mean float64
+
+	for _, freq := range freqs {
+		mean += float64(freq)
+	}
+
+	mean /= float64(len(freqs))
+
+	var variance float64
+
+	for _, freq := range freqs {
+		diff := float64(freq) - mean
+
+		variance += diff * diff
+	}
+
+	variance /= float64(len(freqs))
+
+	stddev := math.Sqrt(variance)
+
+	t.Log("mean", mean, "stddev", stddev, fmt.Sprintf("(%f%%)", stddev*100/mean))
+}
+
+// TestGenerateTimeWindow ensures time window generation spits out times when
+// we expect it to.
+func TestGenerateTimeWindow(t *testing.T) {
+	t.Parallel()
+
+	// Keep tabs on what days of the week and hours things get scheduled.
+	daysOfWeek := map[int]int{}
+	hoursOfDay := map[int]int{}
+
+	// This is driven by RANDOM, so use enough iterations to be statistically
+	// significant.
+	for i := 0; i < samples; i++ {
+		window := util.GenerateTimeWindow(uuid.New().String())
+
+		// We shouldn't be triggering fails unless we're in the office to
+		// deal with them.
+		if window.Start.Weekday() == time.Friday || window.Start.Weekday() == time.Saturday {
+			t.Fatal("start time is when we should be sipping pina coladas")
+		}
+
+		daysOfWeek[int(window.Start.Weekday())]++
+
+		// We shouldn't be triggering fails during the working day.
+		if window.Start.Hour() > 7 {
+			t.Fatal("start time is during the working day")
+		}
+
+		hoursOfDay[window.Start.Hour()]++
+
+		if window.End.Sub(window.Start) != time.Hour {
+			t.Fatal("end time isn't one hour after the start time")
+		}
+	}
+
+	// As a final check, ensure all the expected indices are there.
+	for i := time.Sunday; i != time.Friday; i++ {
+		if _, ok := daysOfWeek[int(i)]; !ok {
+			t.Fatal("Nothing scheduled on", i)
+		}
+	}
+
+	t.Log("day of week statistics")
+	logStats(t, daysOfWeek)
+
+	for i := 0; i < 8; i++ {
+		if _, ok := hoursOfDay[i]; !ok {
+			t.Fatal("Nothing scheduled at", i)
+		}
+	}
+
+	t.Log("time of day statistics")
+	logStats(t, hoursOfDay)
+}


### PR DESCRIPTION
Ensure CP and CL upgrades are based on some form of entropy, are evenly distributed across the allowed upgrade windows, so as not to overwhealm the host cluster too badly.  The allowed windows are Sun-Thur, 00:00-07:00 UTC as we are available for support, and it doesn't impact the working day, taking into account the difference between UTC and CEST.