### PR TITLE
Scale-From-Zero Fixes

### DIFF
--- a/charts/unikorn/templates/applications.yaml
+++ b/charts/unikorn/templates/applications.yaml
@@ -68,6 +68,7 @@ spec:
   repo: https://helm.cilium.io
   chart: cilium
   version: 1.12.4
+  interface: 1.0.0
 ---
 apiVersion: unikorn.eschercloud.ai/v1alpha1
 kind: HelmApplication
@@ -87,7 +88,7 @@ metadata:
 spec:
   repo: https://eschercloudai.github.io/helm-cluster-api
   chart: cluster-api-cluster-openstack
-  version: v0.3.13
+  version: v0.3.14
   createNamespace: true
   interface: 1.0.0
 ---

--- a/pkg/provisioners/helmapplications/nvidiagpuoperator/provisioner.go
+++ b/pkg/provisioners/helmapplications/nvidiagpuoperator/provisioner.go
@@ -17,16 +17,10 @@ limitations under the License.
 package nvidiagpuoperator
 
 import (
-	"context"
-
 	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
 	"github.com/eschercloudai/unikorn/pkg/provisioners"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/application"
-	"github.com/eschercloudai/unikorn/pkg/provisioners/generic"
-	"github.com/eschercloudai/unikorn/pkg/provisioners/serial"
-
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/eschercloudai/unikorn/pkg/provisioners/util"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -38,56 +32,19 @@ const (
 	// defaultNamespace is where to install the component.
 	// NOTE: this requires the namespace to exist first, so pick an existing one.
 	defaultNamespace = "kube-system"
-
-	// licenseConfigMapName is the name of the config map we will create.
-	licenseConfigMapName = "gridd-license"
 )
 
-// Provisioner encapsulates control plane provisioning.
-type Provisioner struct {
-	// client provides access to Kubernetes.
-	client client.Client
-
-	// resource defines the unique resource this provisioner belongs to.
-	resource application.MutuallyExclusiveResource
-
-	// remote is the remote cluster to deploy to.
-	remote provisioners.RemoteCluster
-
-	// application is the application used to identify the Helm chart to use.
-	application *unikornv1.HelmApplication
-
-	// namespace defines where to install the application.
-	namespace string
-}
-
 // New returns a new initialized provisioner object.
-func New(client client.Client, resource application.MutuallyExclusiveResource, application *unikornv1.HelmApplication) provisioners.Provisioner {
-	return &Provisioner{
-		client:      client,
-		resource:    resource,
-		application: application,
-		namespace:   defaultNamespace,
-	}
+func New(client client.Client, resource application.MutuallyExclusiveResource, helm *unikornv1.HelmApplication) provisioners.Provisioner {
+	p := &Provisioner{}
+
+	return application.New(client, applicationName, resource, helm).WithGenerator(p).InNamespace(defaultNamespace)
 }
+
+type Provisioner struct{}
 
 // Ensure the Provisioner interface is implemented.
-var _ provisioners.Provisioner = &Provisioner{}
 var _ application.ValuesGenerator = &Provisioner{}
-
-// OnRemote implements the Provision interface.
-func (p *Provisioner) OnRemote(remote provisioners.RemoteCluster) provisioners.Provisioner {
-	p.remote = remote
-
-	return p
-}
-
-// InNamespace implements the Provision interface.
-func (p *Provisioner) InNamespace(namespace string) provisioners.Provisioner {
-	p.namespace = namespace
-
-	return p
-}
 
 // Generate implements the application.Generator interface.
 func (p *Provisioner) Values(version *string) (interface{}, error) {
@@ -99,9 +56,6 @@ func (p *Provisioner) Values(version *string) (interface{}, error) {
 	values := map[string]interface{}{
 		"driver": map[string]interface{}{
 			"enabled": false,
-			"licensingConfig": map[string]interface{}{
-				"configMapName": licenseConfigMapName,
-			},
 		},
 		"operator": map[string]interface{}{
 			"affinity": map[string]interface{}{
@@ -121,67 +75,9 @@ func (p *Provisioner) Values(version *string) (interface{}, error) {
 					},
 				},
 			},
-			"tolerations": []interface{}{
-				map[string]interface{}{
-					"key":      "node-role.kubernetes.io/master",
-					"operator": "Equal",
-					"effect":   "NoSchedule",
-				},
-				map[string]interface{}{
-					"key":      "node-role.kubernetes.io/control-plane",
-					"operator": "Equal",
-					"effect":   "NoSchedule",
-				},
-			},
+			"tolerations": util.ControlPlaneTolerations(),
 		},
 	}
 
 	return values, nil
-}
-
-// generateLicenseConfigMap creates config data for the operator, because it's incapable
-// of doing it itself, because it's obviously way too hard.
-func (p *Provisioner) generateLicenseConfigMapProvisioner() provisioners.Provisioner {
-	object := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      licenseConfigMapName,
-			Namespace: p.namespace,
-		},
-		Data: map[string]string{
-			// TODO: make configurable.
-			// TODO: make mutable.
-			"gridd.conf": "ServerAddress=gridlicense.nl1.eschercloud.com",
-		},
-	}
-
-	return generic.NewResourceProvisioner(p.client, object).OnRemote(p.remote)
-}
-
-func (p *Provisioner) getProvisioner() provisioners.Provisioner {
-	return application.New(p.client, applicationName, p.resource, p.application).WithGenerator(p).OnRemote(p.remote).InNamespace(p.namespace)
-}
-
-// Provision implements the Provision interface.
-func (p *Provisioner) Provision(ctx context.Context) error {
-	provisioner := serial.New("nvidia GPU operator",
-		// TODO: delete me when baked into the image.
-		p.generateLicenseConfigMapProvisioner(),
-		p.getProvisioner(),
-	)
-
-	if err := provisioner.Provision(ctx); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// Deprovision implements the Provision interface.
-func (p *Provisioner) Deprovision(ctx context.Context) error {
-	// Ignore the config map, that will be deleted by the cluster.
-	if err := p.getProvisioner().Deprovision(ctx); err != nil {
-		return err
-	}
-
-	return nil
 }

--- a/pkg/provisioners/helmapplications/openstackplugincindercsi/provisioner.go
+++ b/pkg/provisioners/helmapplications/openstackplugincindercsi/provisioner.go
@@ -22,6 +22,7 @@ import (
 	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
 	"github.com/eschercloudai/unikorn/pkg/provisioners"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/application"
+	"github.com/eschercloudai/unikorn/pkg/provisioners/util"
 
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -110,6 +111,15 @@ func (p *Provisioner) Values(version *string) (interface{}, error) {
 	}
 
 	values := map[string]interface{}{
+		// Allow scale to zero.
+		"csi": map[string]interface{}{
+			"plugin": map[string]interface{}{
+				"controllerPlugin": map[string]interface{}{
+					"nodeSelector": util.ControlPlaneNodeSelector(),
+					"tolerations":  util.ControlPlaneTolerations(),
+				},
+			},
+		},
 		"storageClass": map[string]interface{}{
 			"enabled": false,
 			"custom":  strings.Join(yamls, "---\n"),

--- a/pkg/provisioners/util/scheduling.go
+++ b/pkg/provisioners/util/scheduling.go
@@ -22,6 +22,8 @@ package util
 // scale to zero.
 func ControlPlaneTolerations() []interface{} {
 	return []interface{}{
+		// TODO: this is legacy and can be updated when all clusters
+		// are purged of "master" references.
 		map[string]interface{}{
 			"key":    "node-role.kubernetes.io/master",
 			"effect": "NoSchedule",


### PR DESCRIPTION
More precisely scale-to-zero.  We'd always have one node, because a bunch of managed stuff wasn't pinned to the control plane e.g. cilium operator, cinder CSI, and most importantly coreDNS.  Now on 1.26 the "master" label has been removed because of cancel culture, so caoreDNS only tolerates the "control-plane" label and cannot be scheduled there due to the legacy "master" stuff.  So we've updated the cluster chart to not taint control plane nodes with this label.  Now, CAPI being CAPI could choose to run a kubectl command against the API to reconcile this, but instead deems it appropriate to do a rolling upgrade instead!  So be warned.  Also, we need to get rid of the nvidia licence override, as it's baked into the image.  At present, there's no easy way to remove this as it's outside of Argo's remit, so just leave it in place, and it'll vanish on any for of upgrade over time... just be aware.