### PR TITLE
Finish Monitor Upgrades

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -43,7 +43,7 @@ jobs:
     - name: Golang CI/Helm Lint
       run: make lint
     - name: Build Images
-      run: make images
+      run: make charts/unikorn/crds images
     - name: Generated Code Checked In
       run: '[[ -z $(git status --porcelain) ]]'
     - name: Unit Test

--- a/charts/unikorn/crds/unikorn.eschercloud.ai_controlplanes.yaml
+++ b/charts/unikorn/crds/unikorn.eschercloud.ai_controlplanes.yaml
@@ -65,11 +65,13 @@ spec:
                   the platform will automatically choose an upgrade time for your
                   resource.  This will be before a working day (Mon-Fri) and before
                   working hours (00:00-07:00 UTC).  When any property is set the platform
-                  will select the earliest possible upgrade opportunity.
+                  will follow the rules for the upgrade method.
                 properties:
                   weekday:
                     description: WeekDay allows specification of upgrade time windows
-                      on individual days of the week.
+                      on individual days of the week.  The platform will select a
+                      random  upgrade slot within the specified time windows in order
+                      to load balance and mitigate against defects.
                     properties:
                       friday:
                         description: Friday, when specified, provides an upgrade window
@@ -77,6 +79,8 @@ spec:
                         properties:
                           end:
                             description: End is the upgrade window end hour in UTC.
+                            maximum: 23
+                            minimum: 0
                             type: integer
                           start:
                             description: Start is the upgrade window start hour in
@@ -85,6 +89,8 @@ spec:
                               can span days, so start=22 and end=07 will start at
                               22:00 on the selected day, and end 07:00 the following
                               one.
+                            maximum: 23
+                            minimum: 0
                             type: integer
                         required:
                         - end
@@ -96,6 +102,8 @@ spec:
                         properties:
                           end:
                             description: End is the upgrade window end hour in UTC.
+                            maximum: 23
+                            minimum: 0
                             type: integer
                           start:
                             description: Start is the upgrade window start hour in
@@ -104,17 +112,21 @@ spec:
                               can span days, so start=22 and end=07 will start at
                               22:00 on the selected day, and end 07:00 the following
                               one.
+                            maximum: 23
+                            minimum: 0
                             type: integer
                         required:
                         - end
                         - start
                         type: object
                       saturday:
-                        description: Staurday, when specified, provides an upgrade
+                        description: Saturday, when specified, provides an upgrade
                           window on that day.
                         properties:
                           end:
                             description: End is the upgrade window end hour in UTC.
+                            maximum: 23
+                            minimum: 0
                             type: integer
                           start:
                             description: Start is the upgrade window start hour in
@@ -123,6 +135,8 @@ spec:
                               can span days, so start=22 and end=07 will start at
                               22:00 on the selected day, and end 07:00 the following
                               one.
+                            maximum: 23
+                            minimum: 0
                             type: integer
                         required:
                         - end
@@ -134,6 +148,8 @@ spec:
                         properties:
                           end:
                             description: End is the upgrade window end hour in UTC.
+                            maximum: 23
+                            minimum: 0
                             type: integer
                           start:
                             description: Start is the upgrade window start hour in
@@ -142,6 +158,8 @@ spec:
                               can span days, so start=22 and end=07 will start at
                               22:00 on the selected day, and end 07:00 the following
                               one.
+                            maximum: 23
+                            minimum: 0
                             type: integer
                         required:
                         - end
@@ -153,6 +171,8 @@ spec:
                         properties:
                           end:
                             description: End is the upgrade window end hour in UTC.
+                            maximum: 23
+                            minimum: 0
                             type: integer
                           start:
                             description: Start is the upgrade window start hour in
@@ -161,6 +181,8 @@ spec:
                               can span days, so start=22 and end=07 will start at
                               22:00 on the selected day, and end 07:00 the following
                               one.
+                            maximum: 23
+                            minimum: 0
                             type: integer
                         required:
                         - end
@@ -172,6 +194,8 @@ spec:
                         properties:
                           end:
                             description: End is the upgrade window end hour in UTC.
+                            maximum: 23
+                            minimum: 0
                             type: integer
                           start:
                             description: Start is the upgrade window start hour in
@@ -180,6 +204,8 @@ spec:
                               can span days, so start=22 and end=07 will start at
                               22:00 on the selected day, and end 07:00 the following
                               one.
+                            maximum: 23
+                            minimum: 0
                             type: integer
                         required:
                         - end
@@ -191,6 +217,8 @@ spec:
                         properties:
                           end:
                             description: End is the upgrade window end hour in UTC.
+                            maximum: 23
+                            minimum: 0
                             type: integer
                           start:
                             description: Start is the upgrade window start hour in
@@ -199,6 +227,8 @@ spec:
                               can span days, so start=22 and end=07 will start at
                               22:00 on the selected day, and end 07:00 the following
                               one.
+                            maximum: 23
+                            minimum: 0
                             type: integer
                         required:
                         - end

--- a/charts/unikorn/crds/unikorn.eschercloud.ai_kubernetesclusters.yaml
+++ b/charts/unikorn/crds/unikorn.eschercloud.ai_kubernetesclusters.yaml
@@ -93,11 +93,13 @@ spec:
                   the platform will automatically choose an upgrade time for your
                   resource.  This will be before a working day (Mon-Fri) and before
                   working hours (00:00-07:00 UTC).  When any property is set the platform
-                  will select the earliest possible upgrade opportunity.
+                  will follow the rules for the upgrade method.
                 properties:
                   weekday:
                     description: WeekDay allows specification of upgrade time windows
-                      on individual days of the week.
+                      on individual days of the week.  The platform will select a
+                      random  upgrade slot within the specified time windows in order
+                      to load balance and mitigate against defects.
                     properties:
                       friday:
                         description: Friday, when specified, provides an upgrade window
@@ -105,6 +107,8 @@ spec:
                         properties:
                           end:
                             description: End is the upgrade window end hour in UTC.
+                            maximum: 23
+                            minimum: 0
                             type: integer
                           start:
                             description: Start is the upgrade window start hour in
@@ -113,6 +117,8 @@ spec:
                               can span days, so start=22 and end=07 will start at
                               22:00 on the selected day, and end 07:00 the following
                               one.
+                            maximum: 23
+                            minimum: 0
                             type: integer
                         required:
                         - end
@@ -124,6 +130,8 @@ spec:
                         properties:
                           end:
                             description: End is the upgrade window end hour in UTC.
+                            maximum: 23
+                            minimum: 0
                             type: integer
                           start:
                             description: Start is the upgrade window start hour in
@@ -132,17 +140,21 @@ spec:
                               can span days, so start=22 and end=07 will start at
                               22:00 on the selected day, and end 07:00 the following
                               one.
+                            maximum: 23
+                            minimum: 0
                             type: integer
                         required:
                         - end
                         - start
                         type: object
                       saturday:
-                        description: Staurday, when specified, provides an upgrade
+                        description: Saturday, when specified, provides an upgrade
                           window on that day.
                         properties:
                           end:
                             description: End is the upgrade window end hour in UTC.
+                            maximum: 23
+                            minimum: 0
                             type: integer
                           start:
                             description: Start is the upgrade window start hour in
@@ -151,6 +163,8 @@ spec:
                               can span days, so start=22 and end=07 will start at
                               22:00 on the selected day, and end 07:00 the following
                               one.
+                            maximum: 23
+                            minimum: 0
                             type: integer
                         required:
                         - end
@@ -162,6 +176,8 @@ spec:
                         properties:
                           end:
                             description: End is the upgrade window end hour in UTC.
+                            maximum: 23
+                            minimum: 0
                             type: integer
                           start:
                             description: Start is the upgrade window start hour in
@@ -170,6 +186,8 @@ spec:
                               can span days, so start=22 and end=07 will start at
                               22:00 on the selected day, and end 07:00 the following
                               one.
+                            maximum: 23
+                            minimum: 0
                             type: integer
                         required:
                         - end
@@ -181,6 +199,8 @@ spec:
                         properties:
                           end:
                             description: End is the upgrade window end hour in UTC.
+                            maximum: 23
+                            minimum: 0
                             type: integer
                           start:
                             description: Start is the upgrade window start hour in
@@ -189,6 +209,8 @@ spec:
                               can span days, so start=22 and end=07 will start at
                               22:00 on the selected day, and end 07:00 the following
                               one.
+                            maximum: 23
+                            minimum: 0
                             type: integer
                         required:
                         - end
@@ -200,6 +222,8 @@ spec:
                         properties:
                           end:
                             description: End is the upgrade window end hour in UTC.
+                            maximum: 23
+                            minimum: 0
                             type: integer
                           start:
                             description: Start is the upgrade window start hour in
@@ -208,6 +232,8 @@ spec:
                               can span days, so start=22 and end=07 will start at
                               22:00 on the selected day, and end 07:00 the following
                               one.
+                            maximum: 23
+                            minimum: 0
                             type: integer
                         required:
                         - end
@@ -219,6 +245,8 @@ spec:
                         properties:
                           end:
                             description: End is the upgrade window end hour in UTC.
+                            maximum: 23
+                            minimum: 0
                             type: integer
                           start:
                             description: Start is the upgrade window start hour in
@@ -227,6 +255,8 @@ spec:
                               can span days, so start=22 and end=07 will start at
                               22:00 on the selected day, and end 07:00 the following
                               one.
+                            maximum: 23
+                            minimum: 0
                             type: integer
                         required:
                         - end

--- a/pkg/apis/unikorn/v1alpha1/helpers.go
+++ b/pkg/apis/unikorn/v1alpha1/helpers.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/eschercloudai/unikorn/pkg/constants"
 
@@ -416,4 +417,39 @@ func (b *ApplicationBundle) GetApplication(name string) *ApplicationBundleApplic
 	}
 
 	return nil
+}
+
+// Weekdays returns the days of the week that are set in the spec.
+func (s ApplicationBundleAutoUpgradeWeekDaySpec) Weekdays() []time.Weekday {
+	var result []time.Weekday
+
+	if s.Sunday != nil {
+		result = append(result, time.Sunday)
+	}
+
+	if s.Monday != nil {
+		result = append(result, time.Monday)
+	}
+
+	if s.Tuesday != nil {
+		result = append(result, time.Tuesday)
+	}
+
+	if s.Wednesday != nil {
+		result = append(result, time.Wednesday)
+	}
+
+	if s.Thursday != nil {
+		result = append(result, time.Thursday)
+	}
+
+	if s.Friday != nil {
+		result = append(result, time.Friday)
+	}
+
+	if s.Saturday != nil {
+		result = append(result, time.Saturday)
+	}
+
+	return result
 }

--- a/pkg/apis/unikorn/v1alpha1/types.go
+++ b/pkg/apis/unikorn/v1alpha1/types.go
@@ -283,7 +283,7 @@ type ControlPlaneSpec struct {
 	// When no properties are set in the specification, the platform will automatically
 	// choose an upgrade time for your resource.  This will be before a working day
 	// (Mon-Fri) and before working hours (00:00-07:00 UTC).  When any property is set
-	// the platform will select the earliest possible upgrade opportunity.
+	// the platform will follow the rules for the upgrade method.
 	ApplicationBundleAutoUpgrade *ApplicationBundleAutoUpgradeSpec `json:"applicationBundleAutoUpgrade,omitempty"`
 }
 
@@ -530,7 +530,7 @@ type KubernetesClusterSpec struct {
 	// When no properties are set in the specification, the platform will automatically
 	// choose an upgrade time for your resource.  This will be before a working day
 	// (Mon-Fri) and before working hours (00:00-07:00 UTC).  When any property is set
-	// the platform will select the earliest possible upgrade opportunity.
+	// the platform will follow the rules for the upgrade method.
 	ApplicationBundleAutoUpgrade *ApplicationBundleAutoUpgradeSpec `json:"applicationBundleAutoUpgrade,omitempty"`
 }
 
@@ -825,7 +825,9 @@ type ApplicationBundleStatus struct{}
 
 type ApplicationBundleAutoUpgradeSpec struct {
 	// WeekDay allows specification of upgrade time windows on individual
-	// days of the week.
+	// days of the week.  The platform will select a random  upgrade
+	// slot within the specified time windows in order to load balance and
+	// mitigate against defects.
 	WeekDay *ApplicationBundleAutoUpgradeWeekDaySpec `json:"weekday,omitempty"`
 }
 


### PR DESCRIPTION
It came to me in a dream... that auto upgrades are just a subclass of day of the week upgrades, so refactor that to use the same code. Slightly modify the algorithm as a result.  Add in forced upgrades when the bundle is EOL and we're after the time limit.