### PR TITLE
Version 0.3.24

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Consult the [developer documentation](DEVELOPER.md) for local development instru
 Download the official binary (update the version as appropriate):
 
 ```shell
-wget -O ~/bin/unikornctl https://github.com/eschercloudai/unikorn/releases/download/0.3.16/unikornctl-linux-amd64
+wget -O ~/bin/unikornctl https://github.com/eschercloudai/unikorn/releases/download/0.3.24/unikornctl-linux-amd64
 ```
 
 ### Set up shell completion
@@ -232,7 +232,7 @@ spec:
   source:
     path: charts/unikorn
     repoURL: git@github.com:eschercloudai/unikorn
-    targetRevision: 0.3.23
+    targetRevision: 0.3.24
     helm:
       parameters:
       - name: dockerConfig

--- a/charts/unikorn/Chart.yaml
+++ b/charts/unikorn/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for deploying Unikorn
 
 type: application
 
-version: 0.3.23
-appVersion: 0.3.23
+version: 0.3.24
+appVersion: 0.3.24
 
 icon: https://raw.githubusercontent.com/eschercloudai/unikorn/main/icons/default.png

--- a/charts/unikorn/templates/applicationbundles.yaml
+++ b/charts/unikorn/templates/applicationbundles.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   kind: ControlPlane
   version: 1.0.0
-  endOfLife: 2022-04-01T00:00:00Z
+  endOfLife: 2022-05-01T00:00:00Z
   applications:
   - name: vcluster
     reference:
@@ -48,7 +48,7 @@ metadata:
 spec:
   kind: KubernetesCluster
   version: 1.0.0
-  endOfLife: 2022-04-01T00:00:00Z
+  endOfLife: 2022-05-01T00:00:00Z
   applications:
   - name: cluster-openstack
     reference:

--- a/pkg/monitor/upgrade/cluster/check.go
+++ b/pkg/monitor/upgrade/cluster/check.go
@@ -41,7 +41,63 @@ func New(client client.Client) *Checker {
 	}
 }
 
-//nolint:cyclop
+func (c *Checker) upgradeResource(ctx context.Context, resource *unikornv1.KubernetesCluster, bundles *unikornv1.ApplicationBundleList, target *unikornv1.ApplicationBundle) error {
+	logger := log.FromContext(ctx)
+
+	bundle := bundles.Get(resource.ApplicationBundleName())
+	if bundle == nil {
+		return fmt.Errorf("%w: %s", errors.ErrMissingBundle, *resource.Spec.ApplicationBundle)
+	}
+
+	// If the current bundle is in preview, then don't offer to upgrade.
+	if bundle.Spec.Preview != nil && *bundle.Spec.Preview {
+		logger.Info("bundle in preview, ignoring")
+
+		return nil
+	}
+
+	// If the current bundle is the best option already, we are done.
+	if bundle.Name == target.Name {
+		logger.Info("bundle already latest, ignoring")
+
+		return nil
+	}
+
+	upgradable := util.UpgradeableResource(resource)
+
+	if resource.Spec.ApplicationBundleAutoUpgrade == nil {
+		if bundle.Spec.EndOfLife == nil || time.Now().Before(bundle.Spec.EndOfLife.Time) {
+			logger.Info("resource auto-upgrade disabled, ignoring")
+
+			return nil
+		}
+
+		logger.Info("resource auto-upgrade disabled, but bundle is end of life, forcing auto-upgrade")
+
+		upgradable = util.NewForcedUpgradeResource(resource)
+	}
+
+	// Is it allowed to happen now?  Base it on the UID for ultimate randomness,
+	// you can cause a stampede if all the resources are called "default".
+	window := util.TimeWindowFromResource(ctx, upgradable)
+
+	if !window.In() {
+		logger.Info("not in upgrade window, ignoring", "start", window.Start, "end", window.End)
+
+		return nil
+	}
+
+	logger.Info("bundle upgrading", "from", *bundle.Spec.Version, "to", *target.Spec.Version)
+
+	resource.Spec.ApplicationBundle = &target.Name
+
+	if err := c.client.Update(ctx, resource); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (c *Checker) Check(ctx context.Context) error {
 	logger := log.FromContext(ctx)
 
@@ -65,8 +121,8 @@ func (c *Checker) Check(ctx context.Context) error {
 
 	sort.Stable(bundles)
 
-	// Pick the most recent as out upgrade target.
-	upgradeTarget := &bundles.Items[0]
+	// Pick the most recent as our upgrade target.
+	upgradeTarget := &bundles.Items[len(bundles.Items)-1]
 
 	resources := &unikornv1.KubernetesClusterList{}
 
@@ -74,51 +130,14 @@ func (c *Checker) Check(ctx context.Context) error {
 		return err
 	}
 
-	for _, resource := range resources.Items {
+	for i := range resources.Items {
+		resource := &resources.Items[i]
+
 		logger := logger.WithValues("project", resource.Labels[constants.ProjectLabel], "controlplane", resource.Labels[constants.ControlPlaneLabel], "cluster", resource.Name)
 
-		rctx := log.IntoContext(ctx, logger)
-
-		bundle := allBundlesByKind.Get(resource.ApplicationBundleName())
-		if bundle == nil {
-			return fmt.Errorf("%w: %s", errors.ErrMissingBundle, *resource.Spec.ApplicationBundle)
+		if err := c.upgradeResource(log.IntoContext(ctx, logger), resource, allBundlesByKind, upgradeTarget); err != nil {
+			return err
 		}
-
-		// If the current bundle is in preview, then don't offer to upgrade.
-		if bundle.Spec.Preview != nil && *bundle.Spec.Preview {
-			logger.Info("bundle in preview, ignoring")
-			continue
-		}
-
-		// If the current bundle is the best option already, we are done.
-		if bundle.Name == upgradeTarget.Name {
-			logger.Info("bundle already latest, ignoring")
-			continue
-		}
-
-		upgradable := util.UpgradeableResource(resource)
-
-		if resource.Spec.ApplicationBundleAutoUpgrade == nil {
-			if bundle.Spec.EndOfLife == nil || time.Now().Before(bundle.Spec.EndOfLife.Time) {
-				logger.Info("resource auto-upgrade disabled, ignoring")
-				continue
-			}
-
-			logger.Info("resource auto-upgrade disabled, but bundle is end of life, forcing auto-upgrade")
-
-			upgradable = util.NewForcedUpgradeResource(resource)
-		}
-
-		// Is it allowed to happen now?  Base it on the UID for ultimate randomness,
-		// you can cause a stampede if all the resources are called "default".
-		window := util.TimeWindowFromResource(rctx, upgradable)
-
-		if !window.In() {
-			logger.Info("not in upgrade window, ignoring", "start", window.Start, "end", window.End)
-			continue
-		}
-
-		logger.Info("bundle upgrading", "from", *bundle.Spec.Version, "to", *upgradeTarget.Spec.Version)
 	}
 
 	return nil

--- a/pkg/monitor/upgrade/controlplane/check.go
+++ b/pkg/monitor/upgrade/controlplane/check.go
@@ -41,7 +41,63 @@ func New(client client.Client) *Checker {
 	}
 }
 
-//nolint:cyclop
+func (c *Checker) upgradeResource(ctx context.Context, resource *unikornv1.ControlPlane, bundles *unikornv1.ApplicationBundleList, target *unikornv1.ApplicationBundle) error {
+	logger := log.FromContext(ctx)
+
+	bundle := bundles.Get(resource.ApplicationBundleName())
+	if bundle == nil {
+		return fmt.Errorf("%w: %s", errors.ErrMissingBundle, *resource.Spec.ApplicationBundle)
+	}
+
+	// If the current bundle is in preview, then don't offer to upgrade.
+	if bundle.Spec.Preview != nil && *bundle.Spec.Preview {
+		logger.Info("bundle in preview, ignoring")
+
+		return nil
+	}
+
+	// If the current bundle is the best option already, we are done.
+	if bundle.Name == target.Name {
+		logger.Info("bundle already latest, ignoring")
+
+		return nil
+	}
+
+	upgradable := util.UpgradeableResource(resource)
+
+	if resource.Spec.ApplicationBundleAutoUpgrade == nil {
+		if bundle.Spec.EndOfLife == nil || time.Now().Before(bundle.Spec.EndOfLife.Time) {
+			logger.Info("resource auto-upgrade disabled, ignoring")
+
+			return nil
+		}
+
+		logger.Info("resource auto-upgrade disabled, but bundle is end of life, forcing auto-upgrade")
+
+		upgradable = util.NewForcedUpgradeResource(resource)
+	}
+
+	// Is it allowed to happen now?  Base it on the UID for ultimate randomness,
+	// you can cause a stampede if all the resources are called "default".
+	window := util.TimeWindowFromResource(ctx, upgradable)
+
+	if !window.In() {
+		logger.Info("not in upgrade window, ignoring", "start", window.Start, "end", window.End)
+
+		return nil
+	}
+
+	logger.Info("bundle upgrading", "from", *bundle.Spec.Version, "to", *target.Spec.Version)
+
+	resource.Spec.ApplicationBundle = &target.Name
+
+	if err := c.client.Update(ctx, resource); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (c *Checker) Check(ctx context.Context) error {
 	logger := log.FromContext(ctx)
 
@@ -65,8 +121,8 @@ func (c *Checker) Check(ctx context.Context) error {
 
 	sort.Stable(bundles)
 
-	// Pick the most recent as out upgrade target.
-	upgradeTarget := &bundles.Items[0]
+	// Pick the most recent as our upgrade target.
+	upgradeTarget := &bundles.Items[len(bundles.Items)-1]
 
 	resources := &unikornv1.ControlPlaneList{}
 
@@ -74,51 +130,14 @@ func (c *Checker) Check(ctx context.Context) error {
 		return err
 	}
 
-	for _, resource := range resources.Items {
+	for i := range resources.Items {
+		resource := &resources.Items[i]
+
 		logger := logger.WithValues("project", resource.Labels[constants.ProjectLabel], "controlplane", resource.Name)
 
-		rctx := log.IntoContext(ctx, logger)
-
-		bundle := allBundlesByKind.Get(resource.ApplicationBundleName())
-		if bundle == nil {
-			return fmt.Errorf("%w: %s", errors.ErrMissingBundle, *resource.Spec.ApplicationBundle)
+		if err := c.upgradeResource(log.IntoContext(ctx, logger), resource, allBundlesByKind, upgradeTarget); err != nil {
+			return err
 		}
-
-		// If the current bundle is in preview, then don't offer to upgrade.
-		if bundle.Spec.Preview != nil && *bundle.Spec.Preview {
-			logger.Info("bundle in preview, ignoring")
-			continue
-		}
-
-		// If the current bundle is the best option already, we are done.
-		if bundle.Name == upgradeTarget.Name {
-			logger.Info("bundle already latest, ignoring")
-			continue
-		}
-
-		upgradable := util.UpgradeableResource(resource)
-
-		if resource.Spec.ApplicationBundleAutoUpgrade == nil {
-			if bundle.Spec.EndOfLife == nil || time.Now().Before(bundle.Spec.EndOfLife.Time) {
-				logger.Info("resource auto-upgrade disabled, ignoring")
-				continue
-			}
-
-			logger.Info("resource auto-upgrade disabled, but bundle is end of life, forcing auto-upgrade")
-
-			upgradable = util.NewForcedUpgradeResource(resource)
-		}
-
-		// Is it allowed to happen now?  Base it on the UID for ultimate randomness,
-		// you can cause a stampede if all the resources are called "default".
-		window := util.TimeWindowFromResource(rctx, upgradable)
-
-		if !window.In() {
-			logger.Info("not in upgrade window, ignoring", "start", window.Start, "end", window.End)
-			continue
-		}
-
-		logger.Info("bundle upgrading", "from", *bundle.Spec.Version, "to", *upgradeTarget.Spec.Version)
 	}
 
 	return nil


### PR DESCRIPTION
Predominantly auto-upgrade related.  This makes CP 1.0.1 and CL 1.1.0 live, and also marks the old ones EOL 1/5/23, so they WILL be upgraded then.  Additional changes include updates to managed service scheduling (see the commit history).