### PR TITLE
Tweak Caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Consult the [developer documentation](DEVELOPER.md) for local development instru
 Download the official binary (update the version as appropriate):
 
 ```shell
-wget -O ~/bin/unikornctl https://github.com/eschercloudai/unikorn/releases/download/0.3.24/unikornctl-linux-amd64
+wget -O ~/bin/unikornctl https://github.com/eschercloudai/unikorn/releases/download/0.3.25/unikornctl-linux-amd64
 ```
 
 ### Set up shell completion
@@ -232,7 +232,7 @@ spec:
   source:
     path: charts/unikorn
     repoURL: git@github.com:eschercloudai/unikorn
-    targetRevision: 0.3.24
+    targetRevision: 0.3.25
     helm:
       parameters:
       - name: dockerConfig

--- a/charts/unikorn/Chart.yaml
+++ b/charts/unikorn/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for deploying Unikorn
 
 type: application
 
-version: 0.3.24
-appVersion: 0.3.24
+version: 0.3.25
+appVersion: 0.3.25
 
 icon: https://raw.githubusercontent.com/eschercloudai/unikorn/main/icons/default.png

--- a/pkg/server/handler/handler.go
+++ b/pkg/server/handler/handler.go
@@ -294,7 +294,7 @@ func (h *Handler) GetApiV1ApplicationBundlesControlPlane(w http.ResponseWriter, 
 		return
 	}
 
-	h.setCacheable(w)
+	h.setUncacheable(w)
 	util.WriteJSONResponse(w, r, http.StatusOK, result)
 }
 
@@ -305,7 +305,7 @@ func (h *Handler) GetApiV1ApplicationBundlesCluster(w http.ResponseWriter, r *ht
 		return
 	}
 
-	h.setCacheable(w)
+	h.setUncacheable(w)
 	util.WriteJSONResponse(w, r, http.StatusOK, result)
 }
 
@@ -409,7 +409,7 @@ func (h *Handler) GetApiV1ProvidersOpenstackKeyPairs(w http.ResponseWriter, r *h
 		return
 	}
 
-	h.setCacheable(w)
+	h.setUncacheable(w)
 	util.WriteJSONResponse(w, r, http.StatusOK, result)
 }
 
@@ -420,6 +420,6 @@ func (h *Handler) GetApiV1ProvidersOpenstackProjects(w http.ResponseWriter, r *h
 		return
 	}
 
-	h.setCacheable(w)
+	h.setUncacheable(w)
 	util.WriteJSONResponse(w, r, http.StatusOK, result)
 }


### PR DESCRIPTION
Make app bundles uncacheable, it's weird to create a cluster only to be intsantaneously told it's due for an upgrade.  Projects can change quite quickly, and it sucks waiting 24h to be able to use a new one :D Likewise keypairs.