### PR TITLE
Enable Crash Handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Consult the [developer documentation](DEVELOPER.md) for local development instru
 Download the official binary (update the version as appropriate):
 
 ```shell
-wget -O ~/bin/unikornctl https://github.com/eschercloudai/unikorn/releases/download/0.3.25/unikornctl-linux-amd64
+wget -O ~/bin/unikornctl https://github.com/eschercloudai/unikorn/releases/download/0.3.26/unikornctl-linux-amd64
 ```
 
 ### Set up shell completion
@@ -232,7 +232,7 @@ spec:
   source:
     path: charts/unikorn
     repoURL: git@github.com:eschercloudai/unikorn
-    targetRevision: 0.3.25
+    targetRevision: 0.3.26
     helm:
       parameters:
       - name: dockerConfig

--- a/charts/unikorn/Chart.yaml
+++ b/charts/unikorn/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for deploying Unikorn
 
 type: application
 
-version: 0.3.25
-appVersion: 0.3.25
+version: 0.3.26
+appVersion: 0.3.26
 
 icon: https://raw.githubusercontent.com/eschercloudai/unikorn/main/icons/default.png

--- a/pkg/managers/common/init.go
+++ b/pkg/managers/common/init.go
@@ -98,9 +98,14 @@ func getManager() (manager.Manager, error) {
 
 // getController returns a generic controller.
 func getController(o *options.Options, manager manager.Manager, f ControllerFactory) (controller.Controller, error) {
+	// This prevents a single bad reconcile from affecting all the rest by
+	// boning the whole container.
+	recoverPanic := true
+
 	controllerOptions := controller.Options{
 		Reconciler:              f.Reconciler(manager),
 		MaxConcurrentReconciles: o.MaxConcurrentReconciles,
+		RecoverPanic:            &recoverPanic,
 	}
 
 	c, err := controller.New(constants.Application, manager, controllerOptions)


### PR DESCRIPTION
A single bad resource should not affect all the others (by crashing hard).  Enable recovery handers.