### PR TITLE
Schedule NGINX onto worker nodes

### DIFF
--- a/pkg/provisioners/helmapplications/nginxingress/provisioner.go
+++ b/pkg/provisioners/helmapplications/nginxingress/provisioner.go
@@ -20,7 +20,6 @@ import (
 	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
 	"github.com/eschercloudai/unikorn/pkg/provisioners"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/application"
-	"github.com/eschercloudai/unikorn/pkg/provisioners/util"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -32,30 +31,7 @@ const (
 
 type Provisioner struct{}
 
-// Ensure the Provisioner interface is implemented.
-var _ application.ValuesGenerator = &Provisioner{}
-
 // New returns a new initialized provisioner object.
 func New(client client.Client, resource application.MutuallyExclusiveResource, helm *unikornv1.HelmApplication) provisioners.Provisioner {
-	p := &Provisioner{}
-
-	return application.New(client, applicationName, resource, helm).WithGenerator(p).InNamespace("nginx-system")
-}
-
-// Generate implements the application.Generator interface.
-// This forces the ingress onto the control plane rather than take up a
-// worker node (and thus incur the ire of users).
-func (p *Provisioner) Values(version *string) (interface{}, error) {
-	values := map[string]interface{}{
-		"controller": map[string]interface{}{
-			"tolerations":  util.ControlPlaneTolerations(),
-			"nodeSelector": util.ControlPlaneNodeSelector(),
-		},
-		"defaultBackend": map[string]interface{}{
-			"tolerations":  util.ControlPlaneTolerations(),
-			"nodeSelector": util.ControlPlaneNodeSelector(),
-		},
-	}
-
-	return values, nil
+	return application.New(client, applicationName, resource, helm).InNamespace("nginx-system")
 }


### PR DESCRIPTION
Since CAPO doesn't create Security Group rules for NodePort ranges for control plane nodes, scheduling the NGINX Ingress Controller onto these nodes by default results in a non-functional configuration.

Remove the options to specify the scheduling considerations, and instead go with the defaults.