### PR TITLE
Fix Namespace Scoping

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Consult the [developer documentation](DEVELOPER.md) for local development instru
 Download the official binary (update the version as appropriate):
 
 ```shell
-wget -O ~/bin/unikornctl https://github.com/eschercloudai/unikorn/releases/download/0.3.26/unikornctl-linux-amd64
+wget -O ~/bin/unikornctl https://github.com/eschercloudai/unikorn/releases/download/0.3.27/unikornctl-linux-amd64
 ```
 
 ### Set up shell completion
@@ -232,7 +232,7 @@ spec:
   source:
     path: charts/unikorn
     repoURL: git@github.com:eschercloudai/unikorn
-    targetRevision: 0.3.26
+    targetRevision: 0.3.27
     helm:
       parameters:
       - name: dockerConfig

--- a/charts/unikorn/Chart.yaml
+++ b/charts/unikorn/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for deploying Unikorn
 
 type: application
 
-version: 0.3.26
-appVersion: 0.3.26
+version: 0.3.27
+appVersion: 0.3.27
 
 icon: https://raw.githubusercontent.com/eschercloudai/unikorn/main/icons/default.png

--- a/charts/unikorn/templates/unikorn-control-plane-manager.yaml
+++ b/charts/unikorn/templates/unikorn-control-plane-manager.yaml
@@ -26,6 +26,7 @@ rules:
   - get
   - watch
   - update
+  - patch
 - apiGroups:
   - unikorn.eschercloud.ai
   resources:
@@ -42,6 +43,7 @@ rules:
   - list
   - watch
   - delete
+  - update
 # Manage clusters (cascading deletion).
 - apiGroups:
   - unikorn.eschercloud.ai

--- a/charts/unikorn/templates/unikorn-project-manager.yaml
+++ b/charts/unikorn/templates/unikorn-project-manager.yaml
@@ -26,6 +26,7 @@ rules:
   - get
   - watch
   - update
+  - patch
 - apiGroups:
   - unikorn.eschercloud.ai
   resources:
@@ -42,6 +43,7 @@ rules:
   - list
   - watch
   - delete
+  - update
 # Manage projects (cascading deletion).
 - apiGroups:
   - unikorn.eschercloud.ai

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.14.0
 	go.opentelemetry.io/otel/sdk v1.14.0
 	go.opentelemetry.io/otel/trace v1.14.0
+	golang.org/x/mod v0.8.0
 	golang.org/x/sync v0.1.0
 	gopkg.in/go-jose/go-jose.v2 v2.6.1
 	k8s.io/api v0.26.3

--- a/go.sum
+++ b/go.sum
@@ -408,6 +408,8 @@ golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=
+golang.org/x/mod v0.8.0 h1:LUYupSeNrTNCGzR/hVBk2NHZO4hXcVaW1k4Qx7rjPx8=
+golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -50,6 +50,19 @@ const (
 	// for them).  Metadata may be upgraded to a later version for any resource.
 	VersionLabel = "unikorn.eschercloud.ai/version"
 
+	// KindLabel is used to match a resource that may be owned by a particular kind.
+	// For example, projects and control planes are modelled on namespaces.  For CPs
+	// you have to select based on project and CP name, because of name reuse, but
+	// this raises the problem that selecting a project's namespace will match multiple
+	// so this provides a concrete type associated with each resource.
+	KindLabel = "unikorn.eschercloud.ai/kind"
+
+	// KindLabelValueProject is used to denote a resource belongs to this type.
+	KindLabelValueProject = "project"
+
+	// KindLabelValueControlPlane is used to denote a resource belongs to this type.
+	KindLabelValueControlPlane = "controlplane"
+
 	// ProjectLabel is a label applied to namespaces to indicate it is under
 	// control of this tool.  Useful for label selection.
 	ProjectLabel = "unikorn.eschercloud.ai/project"

--- a/pkg/managers/cluster/manager.go
+++ b/pkg/managers/cluster/manager.go
@@ -115,3 +115,10 @@ func (*Factory) RegisterWatches(controller controller.Controller) error {
 
 	return nil
 }
+
+// Upgrade can perform metadata upgrades of all versioned resources on restart/upgrade
+// of the controller.  This must not affect the spec in any way as it causes split brain
+// and potential fail.
+func (*Factory) Upgrade(c client.Client) error {
+	return nil
+}

--- a/pkg/managers/controlplane/manager.go
+++ b/pkg/managers/controlplane/manager.go
@@ -17,9 +17,16 @@ limitations under the License.
 package controlplane
 
 import (
-	unikornv1alpha1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
-	"github.com/eschercloudai/unikorn/pkg/managers/common"
+	"context"
 
+	"golang.org/x/mod/semver"
+
+	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
+	"github.com/eschercloudai/unikorn/pkg/constants"
+	"github.com/eschercloudai/unikorn/pkg/managers/common"
+	"github.com/eschercloudai/unikorn/pkg/provisioners/util"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -42,7 +49,74 @@ func (*Factory) Reconciler(manager manager.Manager) reconcile.Reconciler {
 
 // RegisterWatches adds any watches that would trigger a reconcile.
 func (*Factory) RegisterWatches(controller controller.Controller) error {
-	if err := controller.Watch(&source.Kind{Type: &unikornv1alpha1.ControlPlane{}}, &handler.EnqueueRequestForObject{}, &predicate.GenerationChangedPredicate{}); err != nil {
+	if err := controller.Watch(&source.Kind{Type: &unikornv1.ControlPlane{}}, &handler.EnqueueRequestForObject{}, &predicate.GenerationChangedPredicate{}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Upgrade can perform metadata upgrades of all versioned resources on restart/upgrade
+// of the controller.  This must not affect the spec in any way as it causes split brain
+// and potential fail.
+func (*Factory) Upgrade(c client.Client) error {
+	ctx := context.TODO()
+
+	resources := &unikornv1.ControlPlaneList{}
+
+	if err := c.List(ctx, resources, &client.ListOptions{}); err != nil {
+		return err
+	}
+
+	for i := range resources.Items {
+		if err := upgrade(ctx, c, &resources.Items[i]); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// semverLess returns true if a is less than b.
+func semverLess(a, b string) bool {
+	// Note we use un-prefixed tags, the library expects different.
+	return semver.Compare("v"+a, "v"+b) < 0
+}
+
+func upgrade(ctx context.Context, c client.Client, resource *unikornv1.ControlPlane) error {
+	version, ok := resource.Labels[constants.VersionLabel]
+	if !ok {
+		return unikornv1.ErrMissingLabel
+	}
+
+	project, ok := resource.Labels[constants.ProjectLabel]
+	if !ok {
+		return unikornv1.ErrMissingLabel
+	}
+
+	newResource := resource.DeepCopy()
+
+	// In 0.3.27, the underlying namespace for a control plane was augmented with the
+	// "unikorn.eschercloud.ai/kind" label to avoid aliasing with project
+	// namespaces as "unikorn.eschercloud.ai/project" was added to them to provide
+	// scoping.
+	if semverLess(version, "0.3.27") {
+		namespace, err := util.GetResourceNamespaceLegacy(ctx, c, constants.ControlPlaneLabel, resource.Name)
+		if err != nil {
+			return err
+		}
+
+		namespace.Labels[constants.KindLabel] = constants.KindLabelValueControlPlane
+		namespace.Labels[constants.ProjectLabel] = project
+
+		if err := c.Update(ctx, namespace, &client.UpdateOptions{}); err != nil {
+			return err
+		}
+
+		newResource.Labels[constants.VersionLabel] = "0.3.27"
+	}
+
+	if err := c.Patch(ctx, newResource, client.MergeFrom(resource)); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
The namespace lookup was first written with projects, these are global and have unique names, fine.  What we missed was controlpanes are scoped, so you can reuse the name in different projects, so going by name was totally broken.  Like argo apps, use the resource labels function to define a unique selector set, so we rely on control plane name and the project name to provide scoping.  However this in itself is broken in that control planes namespaces now have a project label, therefore will get picked up by the project controller, so we need a new kind label to tell them apart.  But this is broken in that old namespaces have none of the new labels, so we need an upgrade mechanism to add them.