### PR TITLE
Workaround for ArgoCD's insistence on mangling quoted bools

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Consult the [developer documentation](DEVELOPER.md) for local development instru
 Download the official binary (update the version as appropriate):
 
 ```shell
-wget -O ~/bin/unikornctl https://github.com/eschercloudai/unikorn/releases/download/0.3.28/unikornctl-linux-amd64
+wget -O ~/bin/unikornctl https://github.com/eschercloudai/unikorn/releases/download/0.3.29/unikornctl-linux-amd64
 ```
 
 ### Set up shell completion
@@ -232,7 +232,7 @@ spec:
   source:
     path: charts/unikorn
     repoURL: git@github.com:eschercloudai/unikorn
-    targetRevision: 0.3.28
+    targetRevision: 0.3.29
     helm:
       parameters:
       - name: dockerConfig

--- a/charts/unikorn/Chart.yaml
+++ b/charts/unikorn/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for deploying Unikorn
 
 type: application
 
-version: 0.3.28
-appVersion: 0.3.28
+version: 0.3.29
+appVersion: 0.3.29
 
 icon: https://raw.githubusercontent.com/eschercloudai/unikorn/main/icons/default.png

--- a/charts/unikorn/templates/applications.yaml
+++ b/charts/unikorn/templates/applications.yaml
@@ -169,7 +169,7 @@ spec:
   - name: validator.plugin.env[0].name
     value: "WITH_WORKLOAD"
   - name: validator.plugin.env[0].value
-    value: "false"
+    value: f
 ---
 apiVersion: unikorn.eschercloud.ai/v1alpha1
 kind: HelmApplication


### PR DESCRIPTION
The NVIDIA Operator's ClusterPolicy validation explicitly expects a quoted boolean, however along the way ArgoCD flips this from as such to a bool.  One option is to set forceString to true in the Application CR, but as we don't expose this via Unikorn this commit is the workaround where it's ostensibly a string but is correctly interpreted by the NVIDIA Operator.

Refs:

https://github.com/NVIDIA/gpu-operator/blob/9892f06307a2498c2e6eeed43612479919d89801/validator/main.go#L244 https://github.com/NVIDIA/gpu-operator/blob/9892f06307a2498c2e6eeed43612479919d89801/vendor/github.com/urfave/cli/v2/flag_bool.go#L65 https://github.com/argoproj/argo-cd/issues/4428