### PR TITLE
Expose Keystone endpoint configuration options via Helm chart

### DIFF
--- a/charts/unikorn/templates/unikorn-server.yaml
+++ b/charts/unikorn/templates/unikorn-server.yaml
@@ -119,6 +119,12 @@ spec:
         {{- if .Values.server.otlpEndpoint }}
           {{ printf "- --otlp-endpoint=%s" .Values.server.otlpEndpoint | nindent 8 }}
         {{- end }}
+        {{- if .Values.server.keystone.endpoint -}}
+          {{ printf "- --keystone-endpoint=%s" .Values.server.keystone.endpoint | nindent 8 }}
+        {{- end }}
+        {{- if .Values.server.keystone.userDomain -}}
+          {{ printf "- --keystone-user-domain-name=%s" .Values.server.keystone.userDomain | nindent 8 }}
+        {{- end }}
         volumeMounts:
         - name: unikorn-server-jose-tls
           mountPath: /var/lib/secrets/unikorn.eschercloud.ai/jose

--- a/charts/unikorn/values.yaml
+++ b/charts/unikorn/values.yaml
@@ -81,6 +81,10 @@ server:
   # managed by vault.
   imageSigningKey: LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUhZd0VBWUhLb1pJemowQ0FRWUZLNEVFQUNJRFlnQUVmOGs4RVY1TUg4M1BncThYd0JGUTd5YkU2NTEzRlh0awpHaG1jalp4WmYzbU5QOE0vb3VBbE0vZHdYWGpFeXZTNlJhVHdoT3A0aTdHL3VvbE5ZL0RJSCt1elc2VXNxR3VHClFpSW11Tm9BdzFSS1NQcEtyNWlJVXU2eEc1cDR3U3E5Ci0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQo=
 
+  keystone:
+    endpoint: "https://nl1.eschercloud.com:5000"
+    userDomain: "Default"
+
 # UI that works with the server.
 ui:
   # Temporarily block deployment until it's complete.


### PR DESCRIPTION
Provide the ability to configure the OpenStack Keystone URL and default user domain when installing Unikorn Server via the Helm chart.