### PR TITLE
Add Some HTTP01 Issuers

### DIFF
--- a/charts/unikorn/templates/applicationbundles.yaml
+++ b/charts/unikorn/templates/applicationbundles.yaml
@@ -127,3 +127,7 @@ spec:
     reference:
       kind: HelmApplication
       name: cert-manager-1.11.0-1
+  - name: cert-manager-issuers
+    reference:
+      kind: HelmApplication
+      name: cert-manager-issuers-1.0.0-1

--- a/charts/unikorn/templates/applications.yaml
+++ b/charts/unikorn/templates/applications.yaml
@@ -183,3 +183,12 @@ spec:
   version: 0.16.2
   createNamespace: true
   interface: 1.0.0
+---
+apiVersion: unikorn.eschercloud.ai/v1alpha1
+kind: HelmApplication
+metadata:
+  name: cert-manager-issuers-1.0.0-1
+spec:
+  repo: https://eschercloudai.github.io/helm-addons
+  chart: cert-manager-issuers
+  version: 1.0.0

--- a/pkg/provisioners/conditional/provisioner.go
+++ b/pkg/provisioners/conditional/provisioner.go
@@ -61,6 +61,7 @@ func (p *Provisioner) Provision(ctx context.Context) error {
 	log := log.FromContext(ctx)
 
 	if !p.condition() {
+		// TODO: check to see if the application exists, then delete it.
 		log.Info("skipping conditional provision", "provisioner", p.name)
 
 		return nil

--- a/pkg/provisioners/helmapplications/certmanagerissuers/provisioner.go
+++ b/pkg/provisioners/helmapplications/certmanagerissuers/provisioner.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2022-2023 EscherCloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certmanagerissuers
+
+import (
+	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
+	"github.com/eschercloudai/unikorn/pkg/provisioners"
+	"github.com/eschercloudai/unikorn/pkg/provisioners/application"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// applicationName is the unique name of the application.
+	applicationName = "cert-manager-issuers"
+)
+
+// New returns a new initialized provisioner object.
+func New(client client.Client, resource application.MutuallyExclusiveResource, helm *unikornv1.HelmApplication) provisioners.Provisioner {
+	return application.New(client, applicationName, resource, helm)
+}


### PR DESCRIPTION
Makes it way more simple to deploy ingress based services if you've already got an Issuer to refer to.  In this instance, the Kubernetes Dashboard does allow you to create the Ingress, but obviosuly without this in place you don't get TLS.