### PR TITLE
Add Server Metadata

### DIFF
--- a/charts/unikorn/templates/applicationbundles.yaml
+++ b/charts/unikorn/templates/applicationbundles.yaml
@@ -94,7 +94,7 @@ spec:
   - name: cluster-openstack
     reference:
       kind: HelmApplication
-      name: cluster-openstack-0.3.15-1
+      name: cluster-openstack-0.3.16-1
   - name: cilium
     reference:
       kind: HelmApplication

--- a/charts/unikorn/templates/applications.yaml
+++ b/charts/unikorn/templates/applications.yaml
@@ -84,6 +84,17 @@ spec:
 apiVersion: unikorn.eschercloud.ai/v1alpha1
 kind: HelmApplication
 metadata:
+  name: cluster-openstack-0.3.16-1
+spec:
+  repo: https://eschercloudai.github.io/helm-cluster-api
+  chart: cluster-api-cluster-openstack
+  version: v0.3.16
+  createNamespace: true
+  interface: 1.0.0
+---
+apiVersion: unikorn.eschercloud.ai/v1alpha1
+kind: HelmApplication
+metadata:
   name: openstack-cloud-provider-1.4.0-1
 spec:
   repo: https://kubernetes.github.io/cloud-provider-openstack

--- a/pkg/provisioners/helmapplications/clusteropenstack/provisioner.go
+++ b/pkg/provisioners/helmapplications/clusteropenstack/provisioner.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 
 	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
+	"github.com/eschercloudai/unikorn/pkg/constants"
 	"github.com/eschercloudai/unikorn/pkg/provisioners"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/application"
 	"github.com/eschercloudai/unikorn/pkg/util"
@@ -302,6 +303,17 @@ func (p *Provisioner) Values(version *string) (interface{}, error) {
 		openstackValues["sshKeyName"] = *p.cluster.Spec.Openstack.SSHKeyName
 	}
 
+	labels, err := p.cluster.ResourceLabels()
+	if err != nil {
+		return nil, err
+	}
+
+	serverMetadata := map[string]interface{}{
+		"cluster":      p.cluster.Name,
+		"controlPlane": labels[constants.ControlPlaneLabel],
+		"project":      labels[constants.ProjectLabel],
+	}
+
 	// TODO: generate types from the Helm values schema.
 	values := map[string]interface{}{
 		"openstack": openstackValues,
@@ -315,6 +327,7 @@ func (p *Provisioner) Values(version *string) (interface{}, error) {
 					"value":  "true",
 				},
 			},
+			"serverMetadata": serverMetadata,
 		},
 		"controlPlane": map[string]interface{}{
 			"version":  string(*p.cluster.Spec.ControlPlane.Version),


### PR DESCRIPTION
Adds cluster, controlPlane and project to all machines for easily tracing where they came from.