### PR TITLE
Upgrade cluster-autoscaler to 1.27.1

### DIFF
--- a/charts/unikorn/templates/applicationbundles.yaml
+++ b/charts/unikorn/templates/applicationbundles.yaml
@@ -96,7 +96,11 @@ spec:
   - name: cluster-autoscaler
     reference:
       kind: HelmApplication
-      name: cluster-autoscaler-0.0.0-1
+      name: cluster-autoscaler-1.27.1-1
+  - name: cluster-autoscaler-openstack
+    reference:
+      kind: HelmApplication
+      name: cluster-autoscaler-openstack-0.3.16-1
   - name: nvidia-gpu-operator
     reference:
       kind: HelmApplication

--- a/charts/unikorn/templates/applications.yaml
+++ b/charts/unikorn/templates/applications.yaml
@@ -136,7 +136,6 @@ spec:
 apiVersion: unikorn.eschercloud.ai/v1alpha1
 kind: HelmApplication
 metadata:
-  # Cool story bro (Nick Jones!!)
   name: cluster-autoscaler-0.0.0-1
 spec:
   repo: https://github.com/yankcrime/autoscaler
@@ -155,6 +154,39 @@ spec:
   - name: image.tag
     value: v1.26.1
   interface: 1.0.0
+---
+apiVersion: unikorn.eschercloud.ai/v1alpha1
+kind: HelmApplication
+metadata:
+  name: cluster-autoscaler-1.27.1-1
+spec:
+  repo: https://github.com/kubernetes/autoscaler
+  path: charts/cluster-autoscaler
+  version: cluster-autoscaler-chart-9.29.0
+  interface: 1.0.0
+  parameters:
+  - name: cloudProvider
+    value: clusterapi
+  - name: clusterAPIMode
+    value: kubeconfig-incluster
+  - name: extraArgs.scale-down-delay-after-add
+    value: 5m
+  - name: extraArgs.scale-down-unneeded-time
+    value: 5m
+  - name: image.tag
+    value: v1.27.1
+  - name: rbac.serviceAccount.name
+    value: cluster-autoscaler
+  interface: 1.0.0
+---
+apiVersion: unikorn.eschercloud.ai/v1alpha1
+kind: HelmApplication
+metadata:
+  name: cluster-autoscaler-openstack-0.3.16-1
+spec:
+  repo: https://eschercloudai.github.io/helm-cluster-api
+  chart: cluster-api-cluster-autoscaler-openstack
+  version: v0.1.0
 ---
 apiVersion: unikorn.eschercloud.ai/v1alpha1
 kind: HelmApplication

--- a/pkg/provisioners/helmapplications/clusterautoscaleropenstack/provisioner.go
+++ b/pkg/provisioners/helmapplications/clusterautoscaleropenstack/provisioner.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2022-2023 EscherCloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clusterautoscaleropenstack
+
+import (
+	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
+	"github.com/eschercloudai/unikorn/pkg/provisioners"
+	"github.com/eschercloudai/unikorn/pkg/provisioners/application"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// applicationName is the unique name of the application.
+	applicationName = "cluster-autoscaler-openstack"
+)
+
+// Provisioner encapsulates control plane provisioning.
+type Provisioner struct {
+	// clusterName defines the CAPI cluster name.
+	clusterName string
+
+	// clusterKubeconfigSecretName defines the secret that contains the
+	// kubeconfig for the cluster.
+	clusterKubeconfigSecretName string
+}
+
+// New returns a new initialized provisioner object.
+func New(client client.Client, resource application.MutuallyExclusiveResource, helm *unikornv1.HelmApplication, clusterName, clusterKubeconfigSecretName string) provisioners.Provisioner {
+	provisoner := &Provisioner{
+		clusterName:                 clusterName,
+		clusterKubeconfigSecretName: clusterKubeconfigSecretName,
+	}
+
+	return application.New(client, applicationName, resource, helm).WithGenerator(provisoner)
+}


### PR DESCRIPTION
This commit upgrades the cluster-autoscaler component to 1.27.1.  In doing so it also removes the dependency on a forked version (with RBAC fixes for CAPO resources) and instead provisions a seperate Helm chart with the additions.