### PR TITLE
Inhibit Non-Production Upgrades

### DIFF
--- a/pkg/managers/controlplane/manager.go
+++ b/pkg/managers/controlplane/manager.go
@@ -89,6 +89,14 @@ func upgrade(ctx context.Context, c client.Client, resource *unikornv1.ControlPl
 		return unikornv1.ErrMissingLabel
 	}
 
+	// Skip development versions.  This may lead to people unwittingly using old
+	// resources that don't match the requirements of a newer version, but it's
+	// better than trying to upgrade to a newer version accidentally when it's
+	// already at that version, and legacy resource selection won't work at all.
+	if version == "0.0.0" {
+		return nil
+	}
+
 	project, ok := resource.Labels[constants.ProjectLabel]
 	if !ok {
 		return unikornv1.ErrMissingLabel

--- a/pkg/managers/project/manager.go
+++ b/pkg/managers/project/manager.go
@@ -89,6 +89,14 @@ func upgrade(ctx context.Context, c client.Client, resource *unikornv1.Project) 
 		return unikornv1.ErrMissingLabel
 	}
 
+	// Skip development versions.  This may lead to people unwittingly using old
+	// resources that don't match the requirements of a newer version, but it's
+	// better than trying to upgrade to a newer version accidentally when it's
+	// already at that version, and legacy resource selection won't work at all.
+	if version == "0.0.0" {
+		return nil
+	}
+
 	newResource := resource.DeepCopy()
 
 	// In 0.3.27, the underlying namespace for a project was augmented with the


### PR DESCRIPTION
So when you build non-prod, you end up using the default version 0.0.0, which will trigger every upgrade under the sun.  Problem is whatever's been deployed with this version will use the newest schema/set of requirements, so the upgrades will fail.  Rather than trying to guess what to do (which is to be frank, a hard problem), just opt out of upgrades.

There is a danger that if any changes happen that require an upgrade, things will go horribly wrong :D  But still it's less likely that the above, which will happen on any restart after creating a resource.