### PR TITLE
Fix version reference for cluster-autoscaler-openstack chart

### DIFF
--- a/charts/unikorn/templates/applicationbundles.yaml
+++ b/charts/unikorn/templates/applicationbundles.yaml
@@ -100,7 +100,7 @@ spec:
   - name: cluster-autoscaler-openstack
     reference:
       kind: HelmApplication
-      name: cluster-autoscaler-openstack-0.3.16-1
+      name: cluster-autoscaler-openstack-0.1.0-1
   - name: nvidia-gpu-operator
     reference:
       kind: HelmApplication

--- a/charts/unikorn/templates/applications.yaml
+++ b/charts/unikorn/templates/applications.yaml
@@ -182,7 +182,7 @@ spec:
 apiVersion: unikorn.eschercloud.ai/v1alpha1
 kind: HelmApplication
 metadata:
-  name: cluster-autoscaler-openstack-0.3.16-1
+  name: cluster-autoscaler-openstack-0.1.0-1
 spec:
   repo: https://eschercloudai.github.io/helm-cluster-api
   chart: cluster-api-cluster-autoscaler-openstack


### PR DESCRIPTION
The version suffix semantically references the wrong version.  Update this in the definition so that it makes sense to any poor soul attempting to follow along.