### PR TITLE
Upgrade Virtual Cluster

### DIFF
--- a/charts/unikorn/templates/applicationbundles.yaml
+++ b/charts/unikorn/templates/applicationbundles.yaml
@@ -22,6 +22,28 @@ spec:
 apiVersion: unikorn.eschercloud.ai/v1alpha1
 kind: ApplicationBundle
 metadata:
+  name: control-plane-1.1.0
+spec:
+  kind: ControlPlane
+  version: 1.1.0
+  preview: true
+  applications:
+  - name: vcluster
+    reference:
+      kind: HelmApplication
+      name: vcluster-0.15.0-1
+  - name: cert-manager
+    reference:
+      kind: HelmApplication
+      name: cert-manager-1.11.0-1
+  - name: cluster-api
+    reference:
+      kind: HelmApplication
+      name: cluster-api-0.1.7-1
+---
+apiVersion: unikorn.eschercloud.ai/v1alpha1
+kind: ApplicationBundle
+metadata:
   name: kubernetes-cluster-1.1.0
 spec:
   kind: KubernetesCluster

--- a/charts/unikorn/templates/applications.yaml
+++ b/charts/unikorn/templates/applications.yaml
@@ -25,6 +25,16 @@ spec:
 apiVersion: unikorn.eschercloud.ai/v1alpha1
 kind: HelmApplication
 metadata:
+  name: vcluster-0.15.0-1
+spec:
+  repo: https://charts.loft.sh
+  chart: vcluster
+  version: 0.15.0
+  release: vcluster
+---
+apiVersion: unikorn.eschercloud.ai/v1alpha1
+kind: HelmApplication
+metadata:
   name: cluster-api-0.1.7-1
 spec:
   repo: https://eschercloudai.github.io/helm-cluster-api


### PR DESCRIPTION
Apparently this improves monitoring/telemetry etc.  Ran a CP upgrade, nothing appears affected, the vcluster and managed clusters are still functional and callable.