### PR TITLE
Enable Virtual Cluster Path Mapper

### DIFF
--- a/charts/unikorn/templates/applications.yaml
+++ b/charts/unikorn/templates/applications.yaml
@@ -31,6 +31,9 @@ spec:
   chart: vcluster
   version: 0.15.0
   release: vcluster
+  parameters:
+  - name: hostpathMapper.enabled
+    value: 'true'
 ---
 apiVersion: unikorn.eschercloud.ai/v1alpha1
 kind: HelmApplication


### PR DESCRIPTION
Apparently some eBPF trickery is going on to intercept access/stat/open calls and route them to the right places, so you can now run promtail inside a virtual cluster.