### PR TITLE
Fix Deletion

### DIFF
--- a/charts/unikorn/templates/applications.yaml
+++ b/charts/unikorn/templates/applications.yaml
@@ -44,6 +44,9 @@ spec:
   chart: cluster-api
   version: v0.1.7
   interface: 1.0.0
+  parameters:
+  - name: cluster-api-provider-openstack.image
+    value: spjmurray/capi-openstack-controller-amd64:v0.7.3-simon2
 ---
 apiVersion: unikorn.eschercloud.ai/v1alpha1
 kind: HelmApplication

--- a/pkg/provisioners/concurrent/provisioner.go
+++ b/pkg/provisioners/concurrent/provisioner.go
@@ -45,16 +45,6 @@ func New(name string, provisioners ...provisioners.Provisioner) *Provisioner {
 // Ensure the Provisioner interface is implemented.
 var _ provisioners.Provisioner = &Provisioner{}
 
-// OnRemote implements the Provision interface.
-func (p *Provisioner) OnRemote(_ provisioners.RemoteCluster) provisioners.Provisioner {
-	return p
-}
-
-// InNamespace implements the Provision interface.
-func (p *Provisioner) InNamespace(_ string) provisioners.Provisioner {
-	return p
-}
-
 // Provision implements the Provision interface.
 func (p *Provisioner) Provision(ctx context.Context) error {
 	log := log.FromContext(ctx)

--- a/pkg/provisioners/conditional/provisioner.go
+++ b/pkg/provisioners/conditional/provisioner.go
@@ -46,16 +46,6 @@ func New(name string, condition func() bool, provisioner provisioners.Provisione
 // Ensure the Provisioner interface is implemented.
 var _ provisioners.Provisioner = &Provisioner{}
 
-// OnRemote implements the Provision interface.
-func (p *Provisioner) OnRemote(_ provisioners.RemoteCluster) provisioners.Provisioner {
-	return p
-}
-
-// InNamespace implements the Provision interface.
-func (p *Provisioner) InNamespace(_ string) provisioners.Provisioner {
-	return p
-}
-
 // Provision implements the Provision interface.
 func (p *Provisioner) Provision(ctx context.Context) error {
 	log := log.FromContext(ctx)

--- a/pkg/provisioners/generic/kubectl.go
+++ b/pkg/provisioners/generic/kubectl.go
@@ -58,16 +58,6 @@ func NewKubectlProvisioner(config *genericclioptions.ConfigFlags, path string) *
 	}
 }
 
-// OnRemote implements the Provision interface.
-func (p *KubectlProvisioner) OnRemote(_ provisioners.RemoteCluster) provisioners.Provisioner {
-	return p
-}
-
-// InNamespace implements the Provision interface.
-func (p *KubectlProvisioner) InNamespace(_ string) provisioners.Provisioner {
-	return p
-}
-
 // Provision implements the Provision interface.
 func (p *KubectlProvisioner) Provision(_ context.Context) error {
 	var args []string

--- a/pkg/provisioners/generic/resource.go
+++ b/pkg/provisioners/generic/resource.go
@@ -56,18 +56,6 @@ func NewResourceProvisioner(client client.Client, resource client.Object) *Resou
 	}
 }
 
-// OnRemote implements the Provision interface.
-func (p *ResourceProvisioner) OnRemote(remote provisioners.RemoteCluster) provisioners.Provisioner {
-	p.remote = remote
-
-	return p
-}
-
-// InNamespace implements the Provision interface.
-func (p *ResourceProvisioner) InNamespace(_ string) provisioners.Provisioner {
-	return p
-}
-
 // getClient either uses the current client, or gets a new remote one.
 func (p *ResourceProvisioner) getClient(ctx context.Context) (client.Client, error) {
 	client := p.client

--- a/pkg/provisioners/helmapplications/certmanager/provisioner.go
+++ b/pkg/provisioners/helmapplications/certmanager/provisioner.go
@@ -18,7 +18,6 @@ package certmanager
 
 import (
 	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
-	"github.com/eschercloudai/unikorn/pkg/provisioners"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/application"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -30,7 +29,7 @@ const (
 )
 
 // New returns a new initialized provisioner object.
-func New(client client.Client, resource application.MutuallyExclusiveResource, helm *unikornv1.HelmApplication) provisioners.Provisioner {
+func New(client client.Client, resource application.MutuallyExclusiveResource, helm *unikornv1.HelmApplication) *application.Provisioner {
 	// Cert manager doesn't need any special handling, ensure it's installed in the specified
 	// remote and in the cert-manager namespace.
 	return application.New(client, applicationName, resource, helm).InNamespace(applicationName)

--- a/pkg/provisioners/helmapplications/certmanagerissuers/provisioner.go
+++ b/pkg/provisioners/helmapplications/certmanagerissuers/provisioner.go
@@ -18,7 +18,6 @@ package certmanagerissuers
 
 import (
 	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
-	"github.com/eschercloudai/unikorn/pkg/provisioners"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/application"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -30,6 +29,6 @@ const (
 )
 
 // New returns a new initialized provisioner object.
-func New(client client.Client, resource application.MutuallyExclusiveResource, helm *unikornv1.HelmApplication) provisioners.Provisioner {
+func New(client client.Client, resource application.MutuallyExclusiveResource, helm *unikornv1.HelmApplication) *application.Provisioner {
 	return application.New(client, applicationName, resource, helm)
 }

--- a/pkg/provisioners/helmapplications/cilium/provisioner.go
+++ b/pkg/provisioners/helmapplications/cilium/provisioner.go
@@ -18,7 +18,6 @@ package cilium
 
 import (
 	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
-	"github.com/eschercloudai/unikorn/pkg/provisioners"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/application"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/util"
 
@@ -31,7 +30,7 @@ const (
 )
 
 // New returns a new initialized provisioner object.
-func New(client client.Client, cluster *unikornv1.KubernetesCluster, helm *unikornv1.HelmApplication) provisioners.Provisioner {
+func New(client client.Client, cluster *unikornv1.KubernetesCluster, helm *unikornv1.HelmApplication) *application.Provisioner {
 	provisioner := &Provisioner{
 		cluster: cluster,
 	}

--- a/pkg/provisioners/helmapplications/clusterapi/provisioner.go
+++ b/pkg/provisioners/helmapplications/clusterapi/provisioner.go
@@ -18,7 +18,6 @@ package clusterapi
 
 import (
 	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
-	"github.com/eschercloudai/unikorn/pkg/provisioners"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/application"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -37,7 +36,7 @@ type Provisioner struct{}
 var _ application.Customizer = &Provisioner{}
 
 // New returns a new initialized provisioner object.
-func New(client client.Client, resource application.MutuallyExclusiveResource, helm *unikornv1.HelmApplication) provisioners.Provisioner {
+func New(client client.Client, resource application.MutuallyExclusiveResource, helm *unikornv1.HelmApplication) *application.Provisioner {
 	return application.New(client, applicationName, resource, helm).WithGenerator(&Provisioner{})
 }
 

--- a/pkg/provisioners/helmapplications/clusterautoscaler/provisioner.go
+++ b/pkg/provisioners/helmapplications/clusterautoscaler/provisioner.go
@@ -18,7 +18,6 @@ package clusterautoscaler
 
 import (
 	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
-	"github.com/eschercloudai/unikorn/pkg/provisioners"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/application"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -40,7 +39,7 @@ type Provisioner struct {
 }
 
 // New returns a new initialized provisioner object.
-func New(client client.Client, resource application.MutuallyExclusiveResource, helm *unikornv1.HelmApplication, clusterName, clusterKubeconfigSecretName string) provisioners.Provisioner {
+func New(client client.Client, resource application.MutuallyExclusiveResource, helm *unikornv1.HelmApplication, clusterName, clusterKubeconfigSecretName string) *application.Provisioner {
 	provisoner := &Provisioner{
 		clusterName:                 clusterName,
 		clusterKubeconfigSecretName: clusterKubeconfigSecretName,

--- a/pkg/provisioners/helmapplications/clusterautoscaleropenstack/provisioner.go
+++ b/pkg/provisioners/helmapplications/clusterautoscaleropenstack/provisioner.go
@@ -18,7 +18,6 @@ package clusterautoscaleropenstack
 
 import (
 	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
-	"github.com/eschercloudai/unikorn/pkg/provisioners"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/application"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -40,7 +39,7 @@ type Provisioner struct {
 }
 
 // New returns a new initialized provisioner object.
-func New(client client.Client, resource application.MutuallyExclusiveResource, helm *unikornv1.HelmApplication, clusterName, clusterKubeconfigSecretName string) provisioners.Provisioner {
+func New(client client.Client, resource application.MutuallyExclusiveResource, helm *unikornv1.HelmApplication, clusterName, clusterKubeconfigSecretName string) *application.Provisioner {
 	provisoner := &Provisioner{
 		clusterName:                 clusterName,
 		clusterKubeconfigSecretName: clusterKubeconfigSecretName,

--- a/pkg/provisioners/helmapplications/clusteropenstack/provisioner.go
+++ b/pkg/provisioners/helmapplications/clusteropenstack/provisioner.go
@@ -64,7 +64,7 @@ type Provisioner struct {
 }
 
 // New returns a new initialized provisioner object.
-func New(ctx context.Context, client client.Client, cluster *unikornv1.KubernetesCluster, application *unikornv1.HelmApplication) (provisioners.Provisioner, error) {
+func New(ctx context.Context, client client.Client, cluster *unikornv1.KubernetesCluster, application *unikornv1.HelmApplication) (*Provisioner, error) {
 	// Do this once so it's atomic, we don't want it changing in different
 	// places.
 	workloadPools, err := getWorkloadPools(ctx, client, cluster)
@@ -98,14 +98,14 @@ var _ application.ReleaseNamer = &Provisioner{}
 var _ application.ValuesGenerator = &Provisioner{}
 
 // OnRemote implements the Provision interface.
-func (p *Provisioner) OnRemote(remote provisioners.RemoteCluster) provisioners.Provisioner {
+func (p *Provisioner) OnRemote(remote provisioners.RemoteCluster) *Provisioner {
 	p.remote = remote
 
 	return p
 }
 
 // InNamespace implements the Provision interface.
-func (p *Provisioner) InNamespace(namespace string) provisioners.Provisioner {
+func (p *Provisioner) InNamespace(namespace string) *Provisioner {
 	p.namespace = namespace
 
 	return p

--- a/pkg/provisioners/helmapplications/kubernetesdashboard/provisioner.go
+++ b/pkg/provisioners/helmapplications/kubernetesdashboard/provisioner.go
@@ -53,7 +53,7 @@ type Provisioner struct {
 var _ application.ValuesGenerator = &Provisioner{}
 
 // New returns a new initialized provisioner object.
-func New(client client.Client, resource application.MutuallyExclusiveResource, helm *unikornv1.HelmApplication, remote provisioners.RemoteCluster) provisioners.Provisioner {
+func New(client client.Client, resource application.MutuallyExclusiveResource, helm *unikornv1.HelmApplication, remote provisioners.RemoteCluster) *application.Provisioner {
 	p := &Provisioner{
 		remote: remote,
 	}

--- a/pkg/provisioners/helmapplications/metricsserver/provisioner.go
+++ b/pkg/provisioners/helmapplications/metricsserver/provisioner.go
@@ -18,7 +18,6 @@ package metricsserver
 
 import (
 	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
-	"github.com/eschercloudai/unikorn/pkg/provisioners"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/application"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/util"
 
@@ -36,7 +35,7 @@ type Provisioner struct{}
 var _ application.ValuesGenerator = &Provisioner{}
 
 // New returns a new initialized provisioner object.
-func New(client client.Client, resource application.MutuallyExclusiveResource, helm *unikornv1.HelmApplication) provisioners.Provisioner {
+func New(client client.Client, resource application.MutuallyExclusiveResource, helm *unikornv1.HelmApplication) *application.Provisioner {
 	p := &Provisioner{}
 
 	return application.New(client, applicationName, resource, helm).WithGenerator(p).InNamespace("kube-system")

--- a/pkg/provisioners/helmapplications/nginxingress/provisioner.go
+++ b/pkg/provisioners/helmapplications/nginxingress/provisioner.go
@@ -18,7 +18,6 @@ package nginxingress
 
 import (
 	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
-	"github.com/eschercloudai/unikorn/pkg/provisioners"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/application"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -32,6 +31,6 @@ const (
 type Provisioner struct{}
 
 // New returns a new initialized provisioner object.
-func New(client client.Client, resource application.MutuallyExclusiveResource, helm *unikornv1.HelmApplication) provisioners.Provisioner {
+func New(client client.Client, resource application.MutuallyExclusiveResource, helm *unikornv1.HelmApplication) *application.Provisioner {
 	return application.New(client, applicationName, resource, helm).InNamespace("nginx-system")
 }

--- a/pkg/provisioners/helmapplications/nvidiagpuoperator/provisioner.go
+++ b/pkg/provisioners/helmapplications/nvidiagpuoperator/provisioner.go
@@ -18,7 +18,6 @@ package nvidiagpuoperator
 
 import (
 	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
-	"github.com/eschercloudai/unikorn/pkg/provisioners"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/application"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/util"
 
@@ -35,7 +34,7 @@ const (
 )
 
 // New returns a new initialized provisioner object.
-func New(client client.Client, resource application.MutuallyExclusiveResource, helm *unikornv1.HelmApplication) provisioners.Provisioner {
+func New(client client.Client, resource application.MutuallyExclusiveResource, helm *unikornv1.HelmApplication) *application.Provisioner {
 	p := &Provisioner{}
 
 	return application.New(client, applicationName, resource, helm).WithGenerator(p).InNamespace(defaultNamespace)

--- a/pkg/provisioners/helmapplications/openstackcloudprovider/provisioner.go
+++ b/pkg/provisioners/helmapplications/openstackcloudprovider/provisioner.go
@@ -23,7 +23,6 @@ import (
 	"github.com/gophercloud/utils/openstack/clientconfig"
 
 	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
-	"github.com/eschercloudai/unikorn/pkg/provisioners"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/application"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/util"
 
@@ -49,7 +48,7 @@ type Provisioner struct {
 }
 
 // New returns a new initialized provisioner object.
-func New(client client.Client, cluster *unikornv1.KubernetesCluster, helm *unikornv1.HelmApplication) provisioners.Provisioner {
+func New(client client.Client, cluster *unikornv1.KubernetesCluster, helm *unikornv1.HelmApplication) *application.Provisioner {
 	provisioner := &Provisioner{
 		cluster: cluster,
 	}

--- a/pkg/provisioners/helmapplications/openstackplugincindercsi/provisioner.go
+++ b/pkg/provisioners/helmapplications/openstackplugincindercsi/provisioner.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 
 	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
-	"github.com/eschercloudai/unikorn/pkg/provisioners"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/application"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/util"
 
@@ -48,7 +47,7 @@ type Provisioner struct {
 }
 
 // New returns a new initialized provisioner object.
-func New(client client.Client, cluster *unikornv1.KubernetesCluster, helm *unikornv1.HelmApplication) provisioners.Provisioner {
+func New(client client.Client, cluster *unikornv1.KubernetesCluster, helm *unikornv1.HelmApplication) *application.Provisioner {
 	provisioner := &Provisioner{
 		client:  client,
 		cluster: cluster,

--- a/pkg/provisioners/helmapplications/vcluster/provisioner.go
+++ b/pkg/provisioners/helmapplications/vcluster/provisioner.go
@@ -20,7 +20,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
-	"github.com/eschercloudai/unikorn/pkg/provisioners"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/application"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -55,6 +54,6 @@ func init() {
 }
 
 // New returns a new initialized provisioner object.
-func New(client client.Client, resource application.MutuallyExclusiveResource, helm *unikornv1.HelmApplication) provisioners.Provisioner {
+func New(client client.Client, resource application.MutuallyExclusiveResource, helm *unikornv1.HelmApplication) *application.Provisioner {
 	return application.New(client, applicationName, resource, helm)
 }

--- a/pkg/provisioners/interfaces.go
+++ b/pkg/provisioners/interfaces.go
@@ -46,13 +46,6 @@ type RemoteCluster interface {
 // packages in a technology agnostic way.  For example some things may be
 // installed as a raw set of resources, a YAML manifest, Helm etc.
 type Provisioner interface {
-	// OnRemote allows a provisioner to target a specific cluster.
-	OnRemote(RemoteCluster) Provisioner
-
-	// InNamespace allows the setting of the provisioning namespace
-	// at a generic level.
-	InNamespace(string) Provisioner
-
 	// Provision deploys the requested package.
 	// Implementations should ensure this receiver is idempotent.
 	Provision(context.Context) error

--- a/pkg/provisioners/managers/controlplane/provisioner.go
+++ b/pkg/provisioners/managers/controlplane/provisioner.go
@@ -170,16 +170,6 @@ func (p *Provisioner) getControlPlaneProvisioner(namespace string) provisioners.
 	)
 }
 
-// OnRemote implements the Provision interface.
-func (p *Provisioner) OnRemote(_ provisioners.RemoteCluster) provisioners.Provisioner {
-	return p
-}
-
-// InNamespace implements the Provision interface.
-func (p *Provisioner) InNamespace(_ string) provisioners.Provisioner {
-	return p
-}
-
 // Provision implements the Provision interface.
 func (p *Provisioner) Provision(ctx context.Context) error {
 	log := log.FromContext(ctx)

--- a/pkg/provisioners/managers/project/provisioner.go
+++ b/pkg/provisioners/managers/project/provisioner.go
@@ -55,16 +55,6 @@ func New(client client.Client, project *unikornv1alpha1.Project) *Provisioner {
 // Ensure the Provisioner interface is implemented.
 var _ provisioners.Provisioner = &Provisioner{}
 
-// OnRemote implements the Provision interface.
-func (p *Provisioner) OnRemote(_ provisioners.RemoteCluster) provisioners.Provisioner {
-	return p
-}
-
-// InNamespace implements the Provision interface.
-func (p *Provisioner) InNamespace(_ string) provisioners.Provisioner {
-	return p
-}
-
 // Provision implements the Provision interface.
 func (p *Provisioner) Provision(ctx context.Context) error {
 	labels, err := p.project.ResourceLabels()

--- a/pkg/provisioners/remotecluster/provisioner.go
+++ b/pkg/provisioners/remotecluster/provisioner.go
@@ -85,16 +85,6 @@ func New(client client.Client, generator provisioners.RemoteCluster) *Provisione
 // Ensure the Provisioner interface is implemented.
 var _ provisioners.Provisioner = &Provisioner{}
 
-// OnRemote implements the Provision interface.
-func (p *Provisioner) OnRemote(_ provisioners.RemoteCluster) provisioners.Provisioner {
-	return p
-}
-
-// InNamespace implements the Provision interface.
-func (p *Provisioner) InNamespace(_ string) provisioners.Provisioner {
-	return p
-}
-
 // Provision implements the Provision interface.
 func (p *Provisioner) Provision(ctx context.Context) error {
 	log := log.FromContext(ctx)

--- a/pkg/provisioners/serial/provisioner.go
+++ b/pkg/provisioners/serial/provisioner.go
@@ -42,16 +42,6 @@ func New(name string, provisioners ...provisioners.Provisioner) *Provisioner {
 // Ensure the Provisioner interface is implemented.
 var _ provisioners.Provisioner = &Provisioner{}
 
-// OnRemote implements the Provision interface.
-func (p *Provisioner) OnRemote(_ provisioners.RemoteCluster) provisioners.Provisioner {
-	return p
-}
-
-// InNamespace implements the Provision interface.
-func (p *Provisioner) InNamespace(_ string) provisioners.Provisioner {
-	return p
-}
-
 // Provision implements the Provision interface.
 func (p *Provisioner) Provision(ctx context.Context) error {
 	log := log.FromContext(ctx)


### PR DESCRIPTION
ONCE AND FOR ALL!!!!!  Hopefully... Two bugs, first it appears CAPI/CAPO allow the network infra to be deleted before the machines have been processed.  Said machines obviously rely on the infra, so hang indefinitely.  Second issue is with the new Cilum release with Hubble UI enabled, where it deadlocks trying to delete the pods, but alas the CNI has already been deleted.  Inspired by #139, we can just "background delete" things on the cluster under deletion e.g. ignore tearing down in order, Argo will give up once the remote is deleted correctly.  As a side effect, this gets really quick!