### PR TITLE
Fix Cluster Alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Consult the [developer documentation](DEVELOPER.md) for local development instru
 Download the official binary (update the version as appropriate):
 
 ```shell
-wget -O ~/bin/unikornctl https://github.com/eschercloudai/unikorn/releases/download/0.3.32/unikornctl-linux-amd64
+wget -O ~/bin/unikornctl https://github.com/eschercloudai/unikorn/releases/download/0.3.33/unikornctl-linux-amd64
 ```
 
 ### Set up shell completion
@@ -232,7 +232,7 @@ spec:
   source:
     path: charts/unikorn
     repoURL: git@github.com:eschercloudai/unikorn
-    targetRevision: 0.3.32
+    targetRevision: 0.3.33
     helm:
       parameters:
       - name: dockerConfig

--- a/charts/unikorn/Chart.yaml
+++ b/charts/unikorn/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for deploying Unikorn
 
 type: application
 
-version: 0.3.32
-appVersion: 0.3.32
+version: 0.3.33
+appVersion: 0.3.33
 
 icon: https://raw.githubusercontent.com/eschercloudai/unikorn/main/icons/default.png

--- a/charts/unikorn/templates/applications.yaml
+++ b/charts/unikorn/templates/applications.yaml
@@ -46,7 +46,7 @@ spec:
   interface: 1.0.0
   parameters:
   - name: cluster-api-provider-openstack.image
-    value: spjmurray/capi-openstack-controller-amd64:v0.7.3-simon2
+    value: spjmurray/capi-openstack-controller-amd64:v0.7.3-simon6
 ---
 apiVersion: unikorn.eschercloud.ai/v1alpha1
 kind: HelmApplication

--- a/charts/unikorn/templates/unikorn-cluster-manager.yaml
+++ b/charts/unikorn/templates/unikorn-cluster-manager.yaml
@@ -25,6 +25,7 @@ rules:
   verbs:
   - list
   - get
+  - patch
   - watch
   - update
 - apiGroups:

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -85,6 +85,11 @@ const (
 	// IngressEndpointAnnotation helps us find the ingress IP address.
 	IngressEndpointAnnotation = "unikorn.eschercloud.ai/ingress-endpoint"
 
+	// ForceClusterNameAnnotation supports old snoflake clusters that are
+	// still hanging around whose names could alias across different control
+	// planes when provisioned into a single project.
+	ForceClusterNameAnnotation = "unikorn.eschercloud.ai/force-cluster-name"
+
 	// Finalizer is applied to resources that need to be deleted manually
 	// and do other complex logic.
 	Finalizer = "unikorn"

--- a/pkg/managers/cluster/manager.go
+++ b/pkg/managers/cluster/manager.go
@@ -19,7 +19,9 @@ package cluster
 import (
 	"context"
 
-	unikornv1alpha1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
+	"golang.org/x/mod/semver"
+
+	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
 	"github.com/eschercloudai/unikorn/pkg/constants"
 	"github.com/eschercloudai/unikorn/pkg/managers/common"
 
@@ -106,12 +108,12 @@ func (*Factory) Reconciler(manager manager.Manager) reconcile.Reconciler {
 // RegisterWatches adds any watches that would trigger a reconcile.
 func (*Factory) RegisterWatches(manager manager.Manager, controller controller.Controller) error {
 	// Any changes to the cluster spec, trigger a reconcile.
-	if err := controller.Watch(source.Kind(manager.GetCache(), &unikornv1alpha1.KubernetesCluster{}), &handler.EnqueueRequestForObject{}, &predicate.GenerationChangedPredicate{}); err != nil {
+	if err := controller.Watch(source.Kind(manager.GetCache(), &unikornv1.KubernetesCluster{}), &handler.EnqueueRequestForObject{}, &predicate.GenerationChangedPredicate{}); err != nil {
 		return err
 	}
 
 	// Any changes to workload pools that are selected by the cluster, trigger a reconcile.
-	if err := controller.Watch(source.Kind(manager.GetCache(), &unikornv1alpha1.KubernetesWorkloadPool{}), &eventHandlerOwnerFromLabel{label: constants.KubernetesClusterLabel}, &predicate.GenerationChangedPredicate{}); err != nil {
+	if err := controller.Watch(source.Kind(manager.GetCache(), &unikornv1.KubernetesWorkloadPool{}), &eventHandlerOwnerFromLabel{label: constants.KubernetesClusterLabel}, &predicate.GenerationChangedPredicate{}); err != nil {
 		return err
 	}
 
@@ -122,5 +124,61 @@ func (*Factory) RegisterWatches(manager manager.Manager, controller controller.C
 // of the controller.  This must not affect the spec in any way as it causes split brain
 // and potential fail.
 func (*Factory) Upgrade(c client.Client) error {
+	ctx := context.TODO()
+
+	resources := &unikornv1.KubernetesClusterList{}
+
+	if err := c.List(ctx, resources, &client.ListOptions{}); err != nil {
+		return err
+	}
+
+	for i := range resources.Items {
+		if err := upgrade(ctx, c, &resources.Items[i]); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// semverLess returns true if a is less than b.
+func semverLess(a, b string) bool {
+	// Note we use un-prefixed tags, the library expects different.
+	return semver.Compare("v"+a, "v"+b) < 0
+}
+
+func upgrade(ctx context.Context, c client.Client, resource *unikornv1.KubernetesCluster) error {
+	version, ok := resource.Labels[constants.VersionLabel]
+	if !ok {
+		return unikornv1.ErrMissingLabel
+	}
+
+	// Skip development versions.  This may lead to people unwittingly using old
+	// resources that don't match the requirements of a newer version, but it's
+	// better than trying to upgrade to a newer version accidentally when it's
+	// already at that version, and legacy resource selection won't work at all.
+	if version == "0.0.0" {
+		return nil
+	}
+
+	newResource := resource.DeepCopy()
+
+	// In 0.3.33 we made cluster names unique, so those given the same name in
+	// different control planes didn't end up using the same infrastructure and
+	// deleting each other by accident.
+	if semverLess(version, "0.3.33") {
+		if newResource.Annotations == nil {
+			newResource.Annotations = map[string]string{}
+		}
+
+		newResource.Annotations[constants.ForceClusterNameAnnotation] = newResource.Name
+
+		newResource.Labels[constants.VersionLabel] = "0.3.33"
+	}
+
+	if err := c.Patch(ctx, newResource, client.MergeFrom(resource)); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/pkg/provisioners/helmapplications/clusterautoscaler/provisioner.go
+++ b/pkg/provisioners/helmapplications/clusterautoscaler/provisioner.go
@@ -19,6 +19,7 @@ package clusterautoscaler
 import (
 	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/application"
+	"github.com/eschercloudai/unikorn/pkg/provisioners/helmapplications/clusteropenstack"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -39,10 +40,12 @@ type Provisioner struct {
 }
 
 // New returns a new initialized provisioner object.
-func New(client client.Client, resource application.MutuallyExclusiveResource, helm *unikornv1.HelmApplication, clusterName, clusterKubeconfigSecretName string) *application.Provisioner {
+func New(client client.Client, resource *unikornv1.KubernetesCluster, helm *unikornv1.HelmApplication) *application.Provisioner {
+	releaseName := clusteropenstack.GenerateReleaseName(resource)
+
 	provisoner := &Provisioner{
-		clusterName:                 clusterName,
-		clusterKubeconfigSecretName: clusterKubeconfigSecretName,
+		clusterName:                 releaseName,
+		clusterKubeconfigSecretName: releaseName + "-kubeconfig",
 	}
 
 	return application.New(client, applicationName, resource, helm).WithGenerator(provisoner)

--- a/pkg/provisioners/helmapplications/clusterautoscaleropenstack/provisioner.go
+++ b/pkg/provisioners/helmapplications/clusterautoscaleropenstack/provisioner.go
@@ -28,22 +28,7 @@ const (
 	applicationName = "cluster-autoscaler-openstack"
 )
 
-// Provisioner encapsulates control plane provisioning.
-type Provisioner struct {
-	// clusterName defines the CAPI cluster name.
-	clusterName string
-
-	// clusterKubeconfigSecretName defines the secret that contains the
-	// kubeconfig for the cluster.
-	clusterKubeconfigSecretName string
-}
-
 // New returns a new initialized provisioner object.
-func New(client client.Client, resource application.MutuallyExclusiveResource, helm *unikornv1.HelmApplication, clusterName, clusterKubeconfigSecretName string) *application.Provisioner {
-	provisoner := &Provisioner{
-		clusterName:                 clusterName,
-		clusterKubeconfigSecretName: clusterKubeconfigSecretName,
-	}
-
-	return application.New(client, applicationName, resource, helm).WithGenerator(provisoner)
+func New(client client.Client, resource application.MutuallyExclusiveResource, helm *unikornv1.HelmApplication) *application.Provisioner {
+	return application.New(client, applicationName, resource, helm)
 }

--- a/pkg/provisioners/helmapplications/clusteropenstack/provisioner.go
+++ b/pkg/provisioners/helmapplications/clusteropenstack/provisioner.go
@@ -377,8 +377,17 @@ func (p *Provisioner) Values(version *string) (interface{}, error) {
 	return values, nil
 }
 
+func GenerateReleaseName(cluster *unikornv1.KubernetesCluster) string {
+	name, ok := cluster.Annotations[constants.ForceClusterNameAnnotation]
+	if ok {
+		return name
+	}
+
+	return cluster.Labels[constants.ControlPlaneLabel] + "-" + cluster.Name
+}
+
 func (p *Provisioner) ReleaseName() string {
-	return p.cluster.Name
+	return GenerateReleaseName(p.cluster)
 }
 
 func (p *Provisioner) getProvisioner() provisioners.Provisioner {

--- a/pkg/provisioners/managers/cluster/provisioner.go
+++ b/pkg/provisioners/managers/cluster/provisioner.go
@@ -108,15 +108,15 @@ func (p *Provisioner) getRemoteClusterGenerator(ctx context.Context) (*clusterop
 		return nil, err
 	}
 
-	return clusteropenstack.NewRemoteClusterGenerator(client, p.cluster.Namespace, p.cluster.Name, provisioners.ClusterOpenstackLabelsFromCluster(p.cluster)), nil
+	return clusteropenstack.NewRemoteClusterGenerator(client, p.cluster), nil
 }
 
 func (p *Provisioner) newClusterAutoscalerProvisioner() provisioners.Provisioner {
-	return clusterautoscaler.New(p.client, p.cluster, p.clusterAutoscalerApplication, p.cluster.Name, p.cluster.Name+"-kubeconfig").OnRemote(p.controlPlaneRemote).InNamespace(p.cluster.Name)
+	return clusterautoscaler.New(p.client, p.cluster, p.clusterAutoscalerApplication).OnRemote(p.controlPlaneRemote).InNamespace(p.cluster.Name)
 }
 
 func (p *Provisioner) newClusterAutoscalerOpenStackProvisioner() provisioners.Provisioner {
-	return clusterautoscaleropenstack.New(p.client, p.cluster, p.clusterAutoscalerOpenStackApplication, p.cluster.Name, p.cluster.Name+"-kubeconfig").OnRemote(p.controlPlaneRemote).InNamespace(p.cluster.Name)
+	return clusterautoscaleropenstack.New(p.client, p.cluster, p.clusterAutoscalerOpenStackApplication).OnRemote(p.controlPlaneRemote).InNamespace(p.cluster.Name)
 }
 
 // getAddonsProvisioner returns a generic provisioner for provisioning and deprovisioning.


### PR DESCRIPTION
Clusters with the same name, in different control planes end up in the same network, which kinda works until deleting one deletes the other. Add some scope to the cluster name so it goes into a separate network, but preserve older clusters rather than delete them!

Fixes #238