### PR TITLE
Add a Developer Mode Switch

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -44,7 +44,16 @@ func VersionString() string {
 	return fmt.Sprintf("%s/%s (revision/%s)", Application, Version, Revision)
 }
 
+// IsProduction tells us whether we need to check for silly assumptions that
+// don't exist or are mostly irrelevant in development land.
+func IsProduction() bool {
+	return Version != DeveloperVersion
+}
+
 const (
+	// This is the default version in the Makefile.
+	DeveloperVersion = "0.0.0"
+
 	// VersionLabel is a label applied to resources so we know the application
 	// version that was used to create them (and thus what metadata is valid
 	// for them).  Metadata may be upgraded to a later version for any resource.

--- a/pkg/managers/cluster/manager.go
+++ b/pkg/managers/cluster/manager.go
@@ -18,6 +18,7 @@ package cluster
 
 import (
 	"context"
+	"fmt"
 
 	"golang.org/x/mod/semver"
 
@@ -157,7 +158,11 @@ func upgrade(ctx context.Context, c client.Client, resource *unikornv1.Kubernete
 	// resources that don't match the requirements of a newer version, but it's
 	// better than trying to upgrade to a newer version accidentally when it's
 	// already at that version, and legacy resource selection won't work at all.
-	if version == "0.0.0" {
+	if version == constants.DeveloperVersion {
+		if constants.IsProduction() {
+			return fmt.Errorf("%w: unexpected developer resource", common.ErrUpgrade)
+		}
+
 		return nil
 	}
 

--- a/pkg/managers/common/init.go
+++ b/pkg/managers/common/init.go
@@ -18,6 +18,7 @@ package common
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"os"
 
@@ -41,6 +42,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var (
+	ErrUpgrade = errors.New("resource upgrade error")
 )
 
 // ControllerFactory allows creation of a Unikorn controller with

--- a/pkg/managers/controlplane/manager.go
+++ b/pkg/managers/controlplane/manager.go
@@ -18,6 +18,7 @@ package controlplane
 
 import (
 	"context"
+	"fmt"
 
 	"golang.org/x/mod/semver"
 
@@ -93,7 +94,11 @@ func upgrade(ctx context.Context, c client.Client, resource *unikornv1.ControlPl
 	// resources that don't match the requirements of a newer version, but it's
 	// better than trying to upgrade to a newer version accidentally when it's
 	// already at that version, and legacy resource selection won't work at all.
-	if version == "0.0.0" {
+	if version == constants.DeveloperVersion {
+		if constants.IsProduction() {
+			return fmt.Errorf("%w: unexpected developer resource", common.ErrUpgrade)
+		}
+
 		return nil
 	}
 

--- a/pkg/managers/project/manager.go
+++ b/pkg/managers/project/manager.go
@@ -18,6 +18,7 @@ package project
 
 import (
 	"context"
+	"fmt"
 
 	"golang.org/x/mod/semver"
 
@@ -93,7 +94,11 @@ func upgrade(ctx context.Context, c client.Client, resource *unikornv1.Project) 
 	// resources that don't match the requirements of a newer version, but it's
 	// better than trying to upgrade to a newer version accidentally when it's
 	// already at that version, and legacy resource selection won't work at all.
-	if version == "0.0.0" {
+	if version == constants.DeveloperVersion {
+		if constants.IsProduction() {
+			return fmt.Errorf("%w: unexpected developer resource", common.ErrUpgrade)
+		}
+
 		return nil
 	}
 


### PR DESCRIPTION
Some functionality we don't need most of the time in developer mode, so we can turn it off.  However some resources that were creaed in developer mode will cause havoc in production, so provide a way to handle both cases.