### PR TITLE
Fix Kubeconfig Lookups

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Consult the [developer documentation](DEVELOPER.md) for local development instru
 Download the official binary (update the version as appropriate):
 
 ```shell
-wget -O ~/bin/unikornctl https://github.com/eschercloudai/unikorn/releases/download/0.3.33/unikornctl-linux-amd64
+wget -O ~/bin/unikornctl https://github.com/eschercloudai/unikorn/releases/download/0.3.34/unikornctl-linux-amd64
 ```
 
 ### Set up shell completion
@@ -232,7 +232,7 @@ spec:
   source:
     path: charts/unikorn
     repoURL: git@github.com:eschercloudai/unikorn
-    targetRevision: 0.3.33
+    targetRevision: 0.3.34
     helm:
       parameters:
       - name: dockerConfig

--- a/charts/unikorn/Chart.yaml
+++ b/charts/unikorn/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for deploying Unikorn
 
 type: application
 
-version: 0.3.33
-appVersion: 0.3.33
+version: 0.3.34
+appVersion: 0.3.34
 
 icon: https://raw.githubusercontent.com/eschercloudai/unikorn/main/icons/default.png

--- a/pkg/cmd/get/kubeconfig/kubeconfig_cluster.go
+++ b/pkg/cmd/get/kubeconfig/kubeconfig_cluster.go
@@ -27,6 +27,7 @@ import (
 	"github.com/eschercloudai/unikorn/pkg/cmd/errors"
 	"github.com/eschercloudai/unikorn/pkg/cmd/util"
 	"github.com/eschercloudai/unikorn/pkg/cmd/util/flags"
+	"github.com/eschercloudai/unikorn/pkg/provisioners/helmapplications/clusteropenstack"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/helmapplications/vcluster"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -95,7 +96,12 @@ func (o *getKubeconfigClusterOptions) run() error {
 		return err
 	}
 
-	secret, err := vclusterClient.CoreV1().Secrets(o.clusterFlags.Cluster).Get(context.TODO(), o.clusterFlags.Cluster+"-kubeconfig", metav1.GetOptions{})
+	cluster, err := o.unikornClient.UnikornV1alpha1().KubernetesClusters(namespace).Get(context.TODO(), o.clusterFlags.Cluster, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	secret, err := vclusterClient.CoreV1().Secrets(o.clusterFlags.Cluster).Get(context.TODO(), clusteropenstack.GenerateReleaseName(cluster)+"-kubeconfig", metav1.GetOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/server/handler/cluster/client.go
+++ b/pkg/server/handler/cluster/client.go
@@ -22,6 +22,7 @@ import (
 	"sort"
 
 	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
+	"github.com/eschercloudai/unikorn/pkg/provisioners/helmapplications/clusteropenstack"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/helmapplications/vcluster"
 	"github.com/eschercloudai/unikorn/pkg/server/authorization"
 	"github.com/eschercloudai/unikorn/pkg/server/errors"
@@ -137,9 +138,20 @@ func (c *Client) GetKubeconfig(ctx context.Context, controlPlaneName generated.C
 		return nil, errors.OAuth2ServerError("failed to get control plane client").WithError(err)
 	}
 
+	clusterObjectKey := client.ObjectKey{
+		Namespace: controlPlane.Namespace,
+		Name:      name,
+	}
+
+	cluster := &unikornv1.KubernetesCluster{}
+
+	if err := c.client.Get(ctx, clusterObjectKey, cluster); err != nil {
+		return nil, errors.HTTPNotFound()
+	}
+
 	objectKey := client.ObjectKey{
 		Namespace: name,
-		Name:      name + "-kubeconfig",
+		Name:      clusteropenstack.GenerateReleaseName(cluster) + "-kubeconfig",
 	}
 
 	secret := &corev1.Secret{}


### PR DESCRIPTION
We've changed the name of the KubernetesCluster so they don't alias across control planes, however the unikornctl and server Kubeconfig lookups didn't handle this name change, so fix that up.