### PR TITLE
Workload Pool Deletion FIx

### DIFF
--- a/charts/unikorn/templates/applicationbundles.yaml
+++ b/charts/unikorn/templates/applicationbundles.yaml
@@ -94,7 +94,7 @@ spec:
   - name: cluster-openstack
     reference:
       kind: HelmApplication
-      name: cluster-openstack-0.3.21-1
+      name: cluster-openstack-0.3.22-1
   - name: cilium
     reference:
       kind: HelmApplication
@@ -153,7 +153,7 @@ spec:
   - name: cluster-openstack
     reference:
       kind: HelmApplication
-      name: cluster-openstack-0.3.21-1
+      name: cluster-openstack-0.3.22-1
   - name: cilium
     reference:
       kind: HelmApplication

--- a/charts/unikorn/templates/applications.yaml
+++ b/charts/unikorn/templates/applications.yaml
@@ -100,11 +100,11 @@ spec:
 apiVersion: unikorn.eschercloud.ai/v1alpha1
 kind: HelmApplication
 metadata:
-  name: cluster-openstack-0.3.21-1
+  name: cluster-openstack-0.3.22-1
 spec:
   repo: https://eschercloudai.github.io/helm-cluster-api
   chart: cluster-api-cluster-openstack
-  version: v0.3.21
+  version: v0.3.22
   createNamespace: true
   interface: 1.0.0
 ---

--- a/pkg/apis/unikorn/v1alpha1/types.go
+++ b/pkg/apis/unikorn/v1alpha1/types.go
@@ -362,6 +362,7 @@ type KubernetesWorkloadPoolList struct {
 	Items           []KubernetesWorkloadPool `json:"items"`
 }
 
+// TODO: deprecate me.
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +kubebuilder:resource:scope=Namespaced,categories=all;unikorn
@@ -461,6 +462,7 @@ type KubernetesWorkloadPoolSpec struct {
 	// Name allows overriding the pool name.  Workload pool resources in the same
 	// namespace need unique names, but may apply to different clusters which exist
 	// in their own "namespace".
+	// TODO: deprecate me when the CRD goes.
 	Name *string `json:"name,omitempty"`
 	// FailureDomain is the failure domain to use for the pool.
 	FailureDomain *string `json:"failureDomain,omitempty"`


### PR DESCRIPTION
We delete workload pools manually based on the name generated by helm, which is s***e.  So add in a temporary hack, and add in a new chart that will augment the pool resources with a label so we can directly a) find resources related to that pool and b) compare names natively without any knowledge of the chart's naming/hashing nuances.