### PR TITLE
Refactor Project Provisioner

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Consult the [developer documentation](DEVELOPER.md) for local development instru
 Download the official binary (update the version as appropriate):
 
 ```shell
-wget -O ~/bin/unikornctl https://github.com/eschercloudai/unikorn/releases/download/0.3.38/unikornctl-linux-amd64
+wget -O ~/bin/unikornctl https://github.com/eschercloudai/unikorn/releases/download/0.3.39/unikornctl-linux-amd64
 ```
 
 ### Set up shell completion
@@ -232,7 +232,7 @@ spec:
   source:
     path: charts/unikorn
     repoURL: git@github.com:eschercloudai/unikorn
-    targetRevision: 0.3.38
+    targetRevision: 0.3.39
     helm:
       parameters:
       - name: dockerConfig

--- a/charts/unikorn/Chart.yaml
+++ b/charts/unikorn/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for deploying Unikorn
 
 type: application
 
-version: 0.3.38
-appVersion: 0.3.38
+version: 0.3.39
+appVersion: 0.3.39
 
 icon: https://raw.githubusercontent.com/eschercloudai/unikorn/main/icons/default.png

--- a/pkg/provisioners/util/util.go
+++ b/pkg/provisioners/util/util.go
@@ -21,11 +21,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/eschercloudai/unikorn/pkg/constants"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -42,31 +39,6 @@ func GetResourceNamespace(ctx context.Context, cli client.Client, l labels.Set) 
 
 	if len(namespaces.Items) != 1 {
 		return nil, fmt.Errorf("%w: labels %v", ErrNamespaceLookup, l)
-	}
-
-	return &namespaces.Items[0], nil
-}
-
-func GetResourceNamespaceLegacy(ctx context.Context, cli client.Client, label, name string) (*corev1.Namespace, error) {
-	labelRequirement, err := labels.NewRequirement(label, selection.Equals, []string{name})
-	if err != nil {
-		return nil, err
-	}
-
-	kindRequirement, err := labels.NewRequirement(constants.KindLabel, selection.DoesNotExist, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	selector := labels.Everything().Add(*labelRequirement, *kindRequirement)
-
-	namespaces := &corev1.NamespaceList{}
-	if err := cli.List(ctx, namespaces, &client.ListOptions{LabelSelector: selector}); err != nil {
-		return nil, err
-	}
-
-	if len(namespaces.Items) != 1 {
-		return nil, fmt.Errorf("%w: label %s, name %s", ErrNamespaceLookup, label, name)
 	}
 
 	return &namespaces.Items[0], nil


### PR DESCRIPTION
Bit of a hack yesterday to get things back on line, so go back around and fix it properly.  Also removes some orphaned code, and refactors the cluster provisioner to avoid a deadlock onvolving zero sized workload pools, addons and the autoscaler.