### PR TITLE
Remove "all" Category

### DIFF
--- a/charts/unikorn/crds/unikorn.eschercloud.ai_applicationbundles.yaml
+++ b/charts/unikorn/crds/unikorn.eschercloud.ai_applicationbundles.yaml
@@ -10,7 +10,6 @@ spec:
   group: unikorn.eschercloud.ai
   names:
     categories:
-    - all
     - unikorn
     kind: ApplicationBundle
     listKind: ApplicationBundleList

--- a/charts/unikorn/crds/unikorn.eschercloud.ai_controlplanes.yaml
+++ b/charts/unikorn/crds/unikorn.eschercloud.ai_controlplanes.yaml
@@ -10,7 +10,6 @@ spec:
   group: unikorn.eschercloud.ai
   names:
     categories:
-    - all
     - unikorn
     kind: ControlPlane
     listKind: ControlPlaneList

--- a/charts/unikorn/crds/unikorn.eschercloud.ai_helmapplications.yaml
+++ b/charts/unikorn/crds/unikorn.eschercloud.ai_helmapplications.yaml
@@ -10,7 +10,6 @@ spec:
   group: unikorn.eschercloud.ai
   names:
     categories:
-    - all
     - unikorn
     kind: HelmApplication
     listKind: HelmApplicationList

--- a/charts/unikorn/crds/unikorn.eschercloud.ai_kubernetesclusters.yaml
+++ b/charts/unikorn/crds/unikorn.eschercloud.ai_kubernetesclusters.yaml
@@ -10,7 +10,6 @@ spec:
   group: unikorn.eschercloud.ai
   names:
     categories:
-    - all
     - unikorn
     kind: KubernetesCluster
     listKind: KubernetesClusterList

--- a/charts/unikorn/crds/unikorn.eschercloud.ai_projects.yaml
+++ b/charts/unikorn/crds/unikorn.eschercloud.ai_projects.yaml
@@ -10,7 +10,6 @@ spec:
   group: unikorn.eschercloud.ai
   names:
     categories:
-    - all
     - unikorn
     kind: Project
     listKind: ProjectList

--- a/pkg/apis/unikorn/v1alpha1/types.go
+++ b/pkg/apis/unikorn/v1alpha1/types.go
@@ -163,7 +163,7 @@ type ProjectList struct {
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:scope=Cluster,categories=all;unikorn
+// +kubebuilder:resource:scope=Cluster,categories=unikorn
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="namespace",type="string",JSONPath=".status.namespace"
 // +kubebuilder:printcolumn:name="status",type="string",JSONPath=".status.conditions[?(@.type==\"Available\")].reason"
@@ -255,7 +255,7 @@ type ControlPlaneList struct {
 // resources.
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:scope=Namespaced,categories=all;unikorn
+// +kubebuilder:resource:scope=Namespaced,categories=unikorn
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="bundle",type="string",JSONPath=".spec.applicationBundle"
 // +kubebuilder:printcolumn:name="namespace",type="string",JSONPath=".status.namespace"
@@ -464,7 +464,7 @@ type KubernetesClusterList struct {
 // some other new starlet.
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:scope=Namespaced,categories=all;unikorn
+// +kubebuilder:resource:scope=Namespaced,categories=unikorn
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="bundle",type="string",JSONPath=".spec.applicationBundle"
 // +kubebuilder:printcolumn:name="version",type="string",JSONPath=".spec.controlPlane.version"
@@ -670,7 +670,7 @@ type HelmApplicationList struct {
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:scope=Cluster,categories=all;unikorn
+// +kubebuilder:resource:scope=Cluster,categories=unikorn
 // +kubebuilder:printcolumn:name="repo",type="string",JSONPath=".spec.repo"
 // +kubebuilder:printcolumn:name="chart",type="string",JSONPath=".spec.chart"
 // +kubebuilder:printcolumn:name="version",type="string",JSONPath=".spec.version"
@@ -739,7 +739,7 @@ type ApplicationBundleList struct {
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
-// +kubebuilder:resource:scope=Cluster,categories=all;unikorn
+// +kubebuilder:resource:scope=Cluster,categories=unikorn
 // +kubebuilder:printcolumn:name="kind",type="string",JSONPath=".spec.kind"
 // +kubebuilder:printcolumn:name="version",type="string",JSONPath=".spec.version"
 // +kubebuilder:printcolumn:name="preview",type="string",JSONPath=".spec.preview"


### PR DESCRIPTION
Part of the reason the old management cluster got totalled is because our CRDs are maked as belonging in the "all" category.  We should remove this to make it harder to delete things.  Besides listing all the applications and bundles when doing "all" is kind of a pain in the butt.