### PR TITLE
Fix Credential Rotation

### DIFF
--- a/charts/unikorn/templates/applications.yaml
+++ b/charts/unikorn/templates/applications.yaml
@@ -71,7 +71,7 @@ metadata:
 spec:
   repo: https://kubernetes.github.io/cloud-provider-openstack
   chart: openstack-cloud-controller-manager
-  version: 1.4.0
+  version: 2.28.0-alpha.4
   createNamespace: true
   interface: 1.0.0
 ---
@@ -82,7 +82,7 @@ metadata:
 spec:
   repo: https://kubernetes.github.io/cloud-provider-openstack
   chart: openstack-cinder-csi
-  version: 2.3.0
+  version: 2.28.0-alpha.4
   createNamespace: true
   interface: 1.0.0
   parameters:
@@ -91,6 +91,8 @@ spec:
     value: 'true'
   - name: secret.name
     value: cloud-config
+  - name: secret.hostMount
+    value: 'false'
 ---
 apiVersion: unikorn.eschercloud.ai/v1alpha1
 kind: HelmApplication

--- a/go.mod
+++ b/go.mod
@@ -116,6 +116,7 @@ require (
 	google.golang.org/grpc v1.55.0 // indirect
 	google.golang.org/protobuf v1.30.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/component-base v0.27.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -701,6 +701,8 @@ gopkg.in/go-jose/go-jose.v2 v2.6.1 h1:qEzJlIDmG9q5VO0M/o8tGS65QMHMS1w01TQJB1VPJ4
 gopkg.in/go-jose/go-jose.v2 v2.6.1/go.mod h1:zzZDPkNNw/c9IE7Z9jr11mBZQhKQTMzoEEIoEdZlFBI=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
+gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
+gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -94,6 +94,11 @@ const (
 	// IngressEndpointAnnotation helps us find the ingress IP address.
 	IngressEndpointAnnotation = "unikorn.eschercloud.ai/ingress-endpoint"
 
+	// ConfigurationHashAnnotation is used where application owners refuse to
+	// poll configuration updates and we (and all other users) are forced into
+	// manually restarting services based on a Deployment/DaemonSet changing.
+	ConfigurationHashAnnotation = "unikorn.eschercloud.ai/config-hash"
+
 	// Finalizer is applied to resources that need to be deleted manually
 	// and do other complex logic.
 	Finalizer = "unikorn"

--- a/pkg/provisioners/helmapplications/openstackcloudprovider/provisioner.go
+++ b/pkg/provisioners/helmapplications/openstackcloudprovider/provisioner.go
@@ -17,12 +17,15 @@ limitations under the License.
 package openstackcloudprovider
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 
 	"github.com/gophercloud/utils/openstack/clientconfig"
+	ini "gopkg.in/ini.v1"
 
 	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
+	"github.com/eschercloudai/unikorn/pkg/constants"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/application"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/util"
 
@@ -59,99 +62,83 @@ func New(client client.Client, cluster *unikornv1.KubernetesCluster, helm *uniko
 // Ensure the Provisioner interface is implemented.
 var _ application.ValuesGenerator = &Provisioner{}
 
-// generateGlobalValues does the horrific translation
-// between the myriad ways that OpenStack deems necessary to authenticate to the
-// cloud configuration format.  See:
+// GenerateCloudConfig does the horrific translation between the myriad ways that OpenStack
+// deems necessary to authenticate to the cloud configuration format.  See:
 // https://github.com/kubernetes/cloud-provider-openstack/blob/master/docs/openstack-cloud-controller-manager/using-openstack-cloud-controller-manager.md#config-openstack-cloud-controller-manager
 //
 //nolint:cyclop
-func (p *Provisioner) generateGlobalValues() (map[string]interface{}, error) {
+func GenerateCloudConfig(cluster *unikornv1.KubernetesCluster) (string, error) {
 	var clouds clientconfig.Clouds
 
-	if err := yaml.Unmarshal(*p.cluster.Spec.Openstack.CloudConfig, &clouds); err != nil {
-		return nil, err
+	if err := yaml.Unmarshal(*cluster.Spec.Openstack.CloudConfig, &clouds); err != nil {
+		return "", err
 	}
 
-	cloud, ok := clouds.Clouds[*p.cluster.Spec.Openstack.Cloud]
+	cloud, ok := clouds.Clouds[*cluster.Spec.Openstack.Cloud]
 	if !ok {
-		return nil, fmt.Errorf("%w: cloud '%s' not found in clouds.yaml", ErrCloudConfiguration, *p.cluster.Spec.Openstack.Cloud)
+		return "", fmt.Errorf("%w: cloud '%s' not found in clouds.yaml", ErrCloudConfiguration, *cluster.Spec.Openstack.Cloud)
 	}
 
-	// Like the "openstack" command we require application credentials to
-	// be marked with the correct authentication type, passwords can be
-	// explicitly or implictly typed, because that's just the way of the
-	// world...  Password auth is just a convenience thing for ease of
-	// development.  Production deployments will want to use application
-	// credentials so (possibly external) credentials aren't leaked.  That
-	// said given the whit show that is this code, it may be better to just
-	// kill passwords.
-	global := map[string]interface{}{
-		"auth-url": cloud.AuthInfo.AuthURL,
+	if cloud.AuthType != clientconfig.AuthV3ApplicationCredential {
+		return "", fmt.Errorf("%w: v3applicationcredential auth_type must be specified in clouds.yaml", ErrCloudConfiguration)
 	}
 
-	//nolint:exhaustive
-	switch cloud.AuthType {
-	case "", clientconfig.AuthV3Password:
-		// The user_id field is NOT supported by the provider.
-		if cloud.AuthInfo.Username == "" {
-			return nil, fmt.Errorf("%w: username must be specified in clouds.yaml", ErrCloudConfiguration)
-		}
+	cloudConfig := ini.Empty()
 
-		global["username"] = cloud.AuthInfo.Username
-		global["password"] = cloud.AuthInfo.Password
-
-		// Try a flat, single domain first, then -- failing that -- look
-		// for a more hierarchical topology.
-		switch {
-		case cloud.AuthInfo.DomainID != "":
-			global["domain-id"] = cloud.AuthInfo.DomainID
-		case cloud.AuthInfo.DomainName != "":
-			global["domain-name"] = cloud.AuthInfo.DomainName
-		default:
-			switch {
-			case cloud.AuthInfo.UserDomainID != "":
-				global["user-domain-id"] = cloud.AuthInfo.UserDomainID
-			case cloud.AuthInfo.UserDomainName != "":
-				global["user-domain-name"] = cloud.AuthInfo.UserDomainName
-			default:
-				return nil, fmt.Errorf("%w: domain_name, domain_id, user_domain_name or user_domain_id must be specified in clouds.yaml", ErrCloudConfiguration)
-			}
-
-			switch {
-			case cloud.AuthInfo.ProjectDomainID != "":
-				global["tenant-domain-id"] = cloud.AuthInfo.ProjectDomainID
-			case cloud.AuthInfo.ProjectDomainName != "":
-				global["tenant-domain-name"] = cloud.AuthInfo.ProjectDomainName
-			default:
-				return nil, fmt.Errorf("%w: domain_name, domain_id, project_domain_name or project_domain_id must be specified in clouds.yaml", ErrCloudConfiguration)
-			}
-		}
-
-		switch {
-		case cloud.AuthInfo.ProjectID != "":
-			global["tenant-id"] = cloud.AuthInfo.ProjectID
-		case cloud.AuthInfo.ProjectName != "":
-			global["tenant-name"] = cloud.AuthInfo.ProjectName
-		default:
-			return nil, fmt.Errorf("%w: project_name or project_id must be specified in clouds.yaml", ErrCloudConfiguration)
-		}
-
-	case clientconfig.AuthV3ApplicationCredential:
-		global["application-credential-id"] = cloud.AuthInfo.ApplicationCredentialID
-		global["application-credential-secret"] = cloud.AuthInfo.ApplicationCredentialSecret
-
-	default:
-		return nil, fmt.Errorf("%w: v3password or v3applicationcredential auth_type must be specified in clouds.yaml", ErrCloudConfiguration)
+	global, err := cloudConfig.NewSection("Global")
+	if err != nil {
+		return "", err
 	}
 
-	return global, nil
+	if _, err := global.NewKey("auth-url", cloud.AuthInfo.AuthURL); err != nil {
+		return "", err
+	}
+
+	if _, err := global.NewKey("application-credential-id", cloud.AuthInfo.ApplicationCredentialID); err != nil {
+		return "", err
+	}
+
+	if _, err := global.NewKey("application-credential-secret", cloud.AuthInfo.ApplicationCredentialSecret); err != nil {
+		return "", err
+	}
+
+	loadBalancer, err := cloudConfig.NewSection("LoadBalancer")
+	if err != nil {
+		return "", err
+	}
+
+	if _, err := loadBalancer.NewKey("floating-network-id", *cluster.Spec.Openstack.ExternalNetworkID); err != nil {
+		return "", err
+	}
+
+	blockStorage, err := cloudConfig.NewSection("BlockStorage")
+	if err != nil {
+		return "", err
+	}
+
+	if _, err := blockStorage.NewKey("ignore-volume-az", "true"); err != nil {
+		return "", err
+	}
+
+	buffer := &bytes.Buffer{}
+
+	if _, err := cloudConfig.WriteTo(buffer); err != nil {
+		return "", err
+	}
+
+	return buffer.String(), nil
 }
 
 // Generate implements the application.Generator interface.
 // Note there is an option, to just pass through the clouds.yaml file, however
 // the chart doesn't allow it to be exposed so we need to translate between formats.
 func (p *Provisioner) Values(_ *string) (interface{}, error) {
-	cloudConfigGlobal, err := p.generateGlobalValues()
+	cloudConfig, err := GenerateCloudConfig(p.cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	cloudConfigHash, err := util.GetConfigurationHash(cloudConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -160,16 +147,11 @@ func (p *Provisioner) Values(_ *string) (interface{}, error) {
 	tolerations = append(tolerations, util.ControlPlaneInitTolerations()...)
 
 	values := map[string]interface{}{
-		"cloudConfig": map[string]interface{}{
-			"global": cloudConfigGlobal,
-			"loadBalancer": map[string]interface{}{
-				"floating-network-id": *p.cluster.Spec.Openstack.ExternalNetworkID,
-			},
-			"blockStorage": map[string]interface{}{
-				"ignore-volume-az": true,
-			},
+		"commonAnnotations": map[string]interface{}{
+			constants.ConfigurationHashAnnotation: cloudConfigHash,
 		},
-		"tolerations": tolerations,
+		"cloudConfigContents": cloudConfig,
+		"tolerations":         tolerations,
 		// See https://github.com/kubernetes/cloud-provider-openstack/issues/2049 for
 		// more details, and no-one doing anything about it.
 		"controllerExtraArgs": `{{list "--use-service-account-credentials=false" | toYaml}}`,

--- a/pkg/provisioners/helmapplications/openstackplugincindercsi/provisioner.go
+++ b/pkg/provisioners/helmapplications/openstackplugincindercsi/provisioner.go
@@ -20,7 +20,9 @@ import (
 	"strings"
 
 	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
+	"github.com/eschercloudai/unikorn/pkg/constants"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/application"
+	"github.com/eschercloudai/unikorn/pkg/provisioners/helmapplications/openstackcloudprovider"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/util"
 
 	corev1 "k8s.io/api/core/v1"
@@ -109,7 +111,20 @@ func (p *Provisioner) Values(version *string) (interface{}, error) {
 		yamls[i] = string(y)
 	}
 
+	cloudConfig, err := openstackcloudprovider.GenerateCloudConfig(p.cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	cloudConfigHash, err := util.GetConfigurationHash(cloudConfig)
+	if err != nil {
+		return nil, err
+	}
+
 	values := map[string]interface{}{
+		"commonAnnotations": map[string]interface{}{
+			constants.ConfigurationHashAnnotation: cloudConfigHash,
+		},
 		// Allow scale to zero.
 		"csi": map[string]interface{}{
 			"plugin": map[string]interface{}{

--- a/pkg/provisioners/util/util.go
+++ b/pkg/provisioners/util/util.go
@@ -18,6 +18,8 @@ package util
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/json"
 	"errors"
 	"fmt"
 
@@ -42,4 +44,17 @@ func GetResourceNamespace(ctx context.Context, cli client.Client, l labels.Set) 
 	}
 
 	return &namespaces.Items[0], nil
+}
+
+// GetConfigurationHash is used to restart badly behaved apps that don't respect configuration
+// changes.
+func GetConfigurationHash(config any) (string, error) {
+	configJSON, err := json.Marshal(config)
+	if err != nil {
+		return "", err
+	}
+
+	configHash := sha256.Sum256(configJSON)
+
+	return fmt.Sprintf("%x", configHash), nil
 }


### PR DESCRIPTION
As per usual the "community" are resisting the correct change of having the controllers pick up config changes automatically, instead insisting that every client on the planet needs to manually restart things to achieve that.  Sadly, it's impossible to do this unless you're on the latest and greatest helm chart, so that needs upgrading, then as we need to hash things, we may as well just define our own cloud-config and hash that... hopefully for the time being.