### PR TITLE
Fix Autoscaling with Node Selectors

### DIFF
--- a/charts/unikorn/templates/applicationbundles.yaml
+++ b/charts/unikorn/templates/applicationbundles.yaml
@@ -30,7 +30,7 @@ spec:
   - name: cluster-openstack
     reference:
       kind: HelmApplication
-      name: cluster-openstack-0.3.22-1
+      name: cluster-openstack-0.3.24-1
   - name: cilium
     reference:
       kind: HelmApplication

--- a/charts/unikorn/templates/applications.yaml
+++ b/charts/unikorn/templates/applications.yaml
@@ -56,11 +56,11 @@ spec:
 apiVersion: unikorn.eschercloud.ai/v1alpha1
 kind: HelmApplication
 metadata:
-  name: cluster-openstack-0.3.22-1
+  name: cluster-openstack-0.3.24-1
 spec:
   repo: https://eschercloudai.github.io/helm-cluster-api
   chart: cluster-api-cluster-openstack
-  version: v0.3.23
+  version: v0.3.24
   createNamespace: true
   interface: 1.0.0
 ---


### PR DESCRIPTION
Cluster autoscaler needs to know about the labels a machine deloyment will get in order to fulfil requests where node selectors have been used for a workload.  Why it cannot just look at the
KubeadmConfigurationTemplate is beyond me...