### PR TITLE
Flesh Out Provider Tests Yet More

### DIFF
--- a/pkg/server/handler/applicationbundle/client.go
+++ b/pkg/server/handler/applicationbundle/client.go
@@ -83,7 +83,7 @@ func (c *Client) Get(ctx context.Context, name string) (*generated.ApplicationBu
 	result := &unikornv1.ApplicationBundle{}
 
 	if err := c.client.Get(ctx, client.ObjectKey{Name: name}, result); err != nil {
-		return nil, errors.HTTPNotFound()
+		return nil, errors.HTTPNotFound().WithError(err)
 	}
 
 	return convert(result), nil

--- a/pkg/server/handler/cluster/client.go
+++ b/pkg/server/handler/cluster/client.go
@@ -94,7 +94,7 @@ func (c *Client) get(ctx context.Context, namespace, name string) (*unikornv1.Ku
 
 	if err := c.client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, result); err != nil {
 		if kerrors.IsNotFound(err) {
-			return nil, errors.HTTPNotFound()
+			return nil, errors.HTTPNotFound().WithError(err)
 		}
 
 		return nil, errors.OAuth2ServerError("unable to get cluster").WithError(err)
@@ -150,7 +150,7 @@ func (c *Client) GetKubeconfig(ctx context.Context, controlPlaneName generated.C
 	cluster := &unikornv1.KubernetesCluster{}
 
 	if err := c.client.Get(ctx, clusterObjectKey, cluster); err != nil {
-		return nil, errors.HTTPNotFound()
+		return nil, errors.HTTPNotFound().WithError(err)
 	}
 
 	objectKey := client.ObjectKey{
@@ -314,7 +314,7 @@ func (c *Client) Delete(ctx context.Context, controlPlaneName generated.ControlP
 
 	if err := c.client.Delete(ctx, cluster); err != nil {
 		if kerrors.IsNotFound(err) {
-			return errors.HTTPNotFound()
+			return errors.HTTPNotFound().WithError(err)
 		}
 
 		return errors.OAuth2ServerError("failed to delete cluster").WithError(err)

--- a/pkg/server/handler/controlplane/client.go
+++ b/pkg/server/handler/controlplane/client.go
@@ -193,7 +193,7 @@ func (c *Client) get(ctx context.Context, namespace, name string) (*unikornv1.Co
 
 	if err := c.client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, result); err != nil {
 		if kerrors.IsNotFound(err) {
-			return nil, errors.HTTPNotFound()
+			return nil, errors.HTTPNotFound().WithError(err)
 		}
 
 		return nil, errors.OAuth2ServerError("failed to get control plane").WithError(err)
@@ -288,7 +288,7 @@ func (c *Client) Delete(ctx context.Context, name generated.ControlPlaneNamePara
 
 	if err := c.client.Delete(ctx, controlPlane); err != nil {
 		if kerrors.IsNotFound(err) {
-			return errors.HTTPNotFound()
+			return errors.HTTPNotFound().WithError(err)
 		}
 
 		return errors.OAuth2ServerError("failed to delete control plane").WithError(err)

--- a/pkg/server/handler/project/client.go
+++ b/pkg/server/handler/project/client.go
@@ -123,7 +123,7 @@ func (c *Client) get(ctx context.Context, name string) (*unikornv1.Project, erro
 
 	if err := c.client.Get(ctx, client.ObjectKey{Name: name}, result); err != nil {
 		if kerrors.IsNotFound(err) {
-			return nil, errors.HTTPNotFound()
+			return nil, errors.HTTPNotFound().WithError(err)
 		}
 
 		return nil, errors.OAuth2ServerError("failed to get project").WithError(err)
@@ -207,7 +207,7 @@ func (c *Client) Delete(ctx context.Context) error {
 
 	if err := c.client.Delete(ctx, project); err != nil {
 		if kerrors.IsNotFound(err) {
-			return errors.HTTPNotFound()
+			return errors.HTTPNotFound().WithError(err)
 		}
 
 		return errors.OAuth2ServerError("failed to delete project").WithError(err)

--- a/pkg/server/handler/providers/openstack/openstack.go
+++ b/pkg/server/handler/providers/openstack/openstack.go
@@ -17,6 +17,7 @@ limitations under the License.
 package openstack
 
 import (
+	goerrors "errors"
 	"fmt"
 	"net/http"
 	"sort"
@@ -32,6 +33,10 @@ import (
 	"github.com/eschercloudai/unikorn/pkg/server/errors"
 	"github.com/eschercloudai/unikorn/pkg/server/generated"
 	"github.com/eschercloudai/unikorn/pkg/util"
+)
+
+var (
+	ErrResourceNotFound = goerrors.New("resource not found")
 )
 
 // Openstack provides an HTTP handler for Openstack resources.
@@ -394,7 +399,7 @@ func (o *Openstack) GetFlavor(r *http.Request, name string) (*generated.Openstac
 		}
 	}
 
-	return nil, errors.HTTPNotFound()
+	return nil, errors.HTTPNotFound().WithError(fmt.Errorf("%w: flavor %s", ErrResourceNotFound, name))
 }
 
 // imageSortWrapper sorts images by age.
@@ -469,7 +474,7 @@ func (o *Openstack) GetImage(r *http.Request, name string) (*generated.Openstack
 		}
 	}
 
-	return nil, errors.HTTPNotFound()
+	return nil, errors.HTTPNotFound().WithError(fmt.Errorf("%w: image %s", ErrResourceNotFound, name))
 }
 
 // ListAvailableProjects lists projects that the token has roles associated with.
@@ -509,8 +514,6 @@ func (o *Openstack) ListKeyPairs(r *http.Request) (generated.OpenstackKeyPairs, 
 		return nil, errors.OAuth2ServerError("failed list key pairs").WithError(err)
 	}
 
-	fmt.Println(result)
-
 	keyPairs := generated.OpenstackKeyPairs{}
 
 	for _, keyPair := range result {
@@ -528,8 +531,6 @@ func (o *Openstack) ListKeyPairs(r *http.Request) (generated.OpenstackKeyPairs, 
 		keyPairs = append(keyPairs, k)
 	}
 
-	fmt.Println(keyPairs)
-
 	return keyPairs, nil
 }
 
@@ -542,7 +543,7 @@ func findApplicationCredential(in []applicationcredentials.ApplicationCredential
 		}
 	}
 
-	return nil, errors.HTTPNotFound()
+	return nil, errors.HTTPNotFound().WithError(fmt.Errorf("%w: application credential %s", ErrResourceNotFound, name))
 }
 
 func (o *Openstack) GetApplicationCredential(r *http.Request, name string) (*applicationcredentials.ApplicationCredential, error) {
@@ -635,7 +636,7 @@ func (o *Openstack) GetServerGroup(r *http.Request, name string) (*servergroups.
 
 	switch len(filtered) {
 	case 0:
-		return nil, errors.HTTPNotFound()
+		return nil, errors.HTTPNotFound().WithError(fmt.Errorf("%w: server group %s", ErrResourceNotFound, name))
 	case 1:
 		return &filtered[0], nil
 	default:

--- a/pkg/server/server_fixtures_test.go
+++ b/pkg/server/server_fixtures_test.go
@@ -18,11 +18,12 @@ package server_test
 
 import (
 	"context"
+	"net"
 	"testing"
 
 	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
 	"github.com/eschercloudai/unikorn/pkg/constants"
-	"github.com/eschercloudai/unikorn/pkg/testutil"
+	"github.com/eschercloudai/unikorn/pkg/testutil/assert"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -33,6 +34,8 @@ import (
 // mustCreateProjectFixture creates a project, and its randomly named namespace
 // just as if unikorn-project-manager had picked up the create request, preformed it
 // and also updated the status.
+//
+//nolint:unparam
 func mustCreateProjectFixture(t *testing.T, tc *TestContext, projectID string) *unikornv1.Project {
 	t.Helper()
 
@@ -45,7 +48,7 @@ func mustCreateProjectFixture(t *testing.T, tc *TestContext, projectID string) *
 		},
 	}
 
-	testutil.AssertNilError(t, tc.KubernetesClient().Create(context.TODO(), namespace, &client.CreateOptions{}))
+	assert.NilError(t, tc.KubernetesClient().Create(context.TODO(), namespace, &client.CreateOptions{}))
 
 	project := &unikornv1.Project{
 		ObjectMeta: metav1.ObjectMeta{
@@ -63,7 +66,7 @@ func mustCreateProjectFixture(t *testing.T, tc *TestContext, projectID string) *
 		},
 	}
 
-	testutil.AssertNilError(t, tc.KubernetesClient().Create(context.TODO(), project, &client.CreateOptions{}))
+	assert.NilError(t, tc.KubernetesClient().Create(context.TODO(), project, &client.CreateOptions{}))
 
 	return project
 }
@@ -71,10 +74,12 @@ func mustCreateProjectFixture(t *testing.T, tc *TestContext, projectID string) *
 // mustCreateControlPlaneFixture creates a control plane , and its randomly named namespace
 // just as if unikorn-controlplane-manager had picked up the create request, preformed it
 // and also updated the status.
-func mustCreateControlPlaneFixture(t *testing.T, tc *TestContext, projectNamespace, name string) *unikornv1.ControlPlane {
+//
+//nolint:unparam
+func mustCreateControlPlaneFixture(t *testing.T, tc *TestContext, namespace, name string) *unikornv1.ControlPlane {
 	t.Helper()
 
-	namespace := &corev1.Namespace{
+	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "controlplane-",
 			Labels: map[string]string{
@@ -84,15 +89,20 @@ func mustCreateControlPlaneFixture(t *testing.T, tc *TestContext, projectNamespa
 		},
 	}
 
-	testutil.AssertNilError(t, tc.KubernetesClient().Create(context.TODO(), namespace, &client.CreateOptions{}))
+	assert.NilError(t, tc.KubernetesClient().Create(context.TODO(), ns, &client.CreateOptions{}))
+
+	bundleVersion := controlPlaneApplicationBundleName
 
 	controlPlane := &unikornv1.ControlPlane{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: projectNamespace,
+			Namespace: namespace,
 			Name:      name,
 		},
+		Spec: unikornv1.ControlPlaneSpec{
+			ApplicationBundle: &bundleVersion,
+		},
 		Status: unikornv1.ControlPlaneStatus{
-			Namespace: namespace.Name,
+			Namespace: ns.Name,
 			Conditions: []unikornv1.ControlPlaneCondition{
 				{
 					Type:   unikornv1.ControlPlaneConditionAvailable,
@@ -103,7 +113,158 @@ func mustCreateControlPlaneFixture(t *testing.T, tc *TestContext, projectNamespa
 		},
 	}
 
-	testutil.AssertNilError(t, tc.KubernetesClient().Create(context.TODO(), controlPlane, &client.CreateOptions{}))
+	assert.NilError(t, tc.KubernetesClient().Create(context.TODO(), controlPlane, &client.CreateOptions{}))
 
 	return controlPlane
+}
+
+const (
+	clusterComputeFailureDomain = "danger_nova"
+	clusterStorageFailureDomain = "ceph"
+	clusterSSHKeyName           = "chubb"
+	clusterExternalNetworkID    = "e0c16797-e5db-4ee4-8305-16a72ded2b7e"
+	clusterNodeNetwork          = "1.0.0.0/24"
+	clusterServiceNetwork       = "2.0.0.0/24"
+	clusterPodNetwork           = "3.0.0.0/24"
+	clusterDNSNameserver        = "8.8.8.8"
+	clusterControlPlaneReplicas = 3
+	clusterWorkloadPoolName     = "you-got-to-work-hard"
+	clusterWorkloadPoolReplicas = 10
+)
+
+func mustCreateKubernetesClusterFixture(t *testing.T, tc *TestContext, namespace, name string) {
+	t.Helper()
+
+	bundleName := kubernetesClusterApplicationBundleName
+	computeFailureDomain := clusterComputeFailureDomain
+	storageFailureDomain := clusterStorageFailureDomain
+	sshKeyName := clusterSSHKeyName
+	externalNetworkID := clusterExternalNetworkID
+	controlPlaneReplicas := clusterControlPlaneReplicas
+	controlPlaneImageName := imageName
+	controlPlaneKubernetesVersion := unikornv1.SemanticVersion("v" + imageK8sVersion)
+	controlPlaneFlavor := flavorName
+	workloadPoolReplicas := clusterWorkloadPoolReplicas
+	workloadPoolImageName := imageName
+	workloadPoolKubernetesVersion := unikornv1.SemanticVersion("v" + imageK8sVersion)
+	workloadPoolFlavor := flavorName
+
+	_, nodenetwork, err := net.ParseCIDR(clusterNodeNetwork)
+	assert.NilError(t, err)
+	_, serviceNetwork, err := net.ParseCIDR(clusterServiceNetwork)
+	assert.NilError(t, err)
+	_, podNetwork, err := net.ParseCIDR(clusterPodNetwork)
+	assert.NilError(t, err)
+
+	dnsNameserver := net.ParseIP(clusterDNSNameserver)
+
+	cluster := &unikornv1.KubernetesCluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Spec: unikornv1.KubernetesClusterSpec{
+			ApplicationBundle: &bundleName,
+			Openstack: &unikornv1.KubernetesClusterOpenstackSpec{
+				FailureDomain:       &computeFailureDomain,
+				VolumeFailureDomain: &storageFailureDomain,
+				SSHKeyName:          &sshKeyName,
+				ExternalNetworkID:   &externalNetworkID,
+			},
+			Network: &unikornv1.KubernetesClusterNetworkSpec{
+				NodeNetwork:    &unikornv1.IPv4Prefix{IPNet: *nodenetwork},
+				ServiceNetwork: &unikornv1.IPv4Prefix{IPNet: *serviceNetwork},
+				PodNetwork:     &unikornv1.IPv4Prefix{IPNet: *podNetwork},
+				DNSNameservers: []unikornv1.IPv4Address{
+					{IP: dnsNameserver},
+				},
+			},
+			ControlPlane: &unikornv1.KubernetesClusterControlPlaneSpec{
+				MachineGeneric: unikornv1.MachineGeneric{
+					Replicas: &controlPlaneReplicas,
+					Version:  &controlPlaneKubernetesVersion,
+					Image:    &controlPlaneImageName,
+					Flavor:   &controlPlaneFlavor,
+				},
+			},
+			WorkloadPools: &unikornv1.KubernetesClusterWorkloadPoolsSpec{
+				Pools: []unikornv1.KubernetesClusterWorkloadPoolsPoolSpec{
+					{
+						KubernetesWorkloadPoolSpec: unikornv1.KubernetesWorkloadPoolSpec{
+							Name: clusterWorkloadPoolName,
+							MachineGeneric: unikornv1.MachineGeneric{
+								Replicas: &workloadPoolReplicas,
+								Version:  &workloadPoolKubernetesVersion,
+								Image:    &workloadPoolImageName,
+								Flavor:   &workloadPoolFlavor,
+							},
+						},
+					},
+				},
+			},
+		},
+		Status: unikornv1.KubernetesClusterStatus{
+			Conditions: []unikornv1.KubernetesClusterCondition{
+				{
+					Type:   unikornv1.KubernetesClusterConditionAvailable,
+					Status: corev1.ConditionTrue,
+					Reason: unikornv1.KubernetesClusterConditionReasonProvisioned,
+				},
+			},
+		},
+	}
+
+	assert.NilError(t, tc.KubernetesClient().Create(context.TODO(), cluster, &client.CreateOptions{}))
+}
+
+const (
+	controlPlaneApplicationBundleName    = "control-plane-1.0.0"
+	controlPlaneApplicationBundleVersion = "1.0.0"
+)
+
+// mustCreateControlPlaneApplicationBundleFixture creates a basic application bundle
+// for a control plane.
+func mustCreateControlPlaneApplicationBundleFixture(t *testing.T, tc *TestContext) {
+	t.Helper()
+
+	kind := unikornv1.ApplicationBundleResourceKindControlPlane
+	version := controlPlaneApplicationBundleVersion
+
+	bundle := &unikornv1.ApplicationBundle{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: controlPlaneApplicationBundleName,
+		},
+		Spec: unikornv1.ApplicationBundleSpec{
+			Kind:    &kind,
+			Version: &version,
+		},
+	}
+
+	assert.NilError(t, tc.KubernetesClient().Create(context.TODO(), bundle, &client.CreateOptions{}))
+}
+
+const (
+	kubernetesClusterApplicationBundleName    = "kubernetes-cluster-1.0.0"
+	kubernetesClusterApplicationBundleVersion = "2.0.0"
+)
+
+// mustKubernetesClusterApplicationBundleFixture creates a basic application bundle
+// for a Kubernetes cluster.
+func mustKubernetesClusterApplicationBundleFixture(t *testing.T, tc *TestContext) {
+	t.Helper()
+
+	kind := unikornv1.ApplicationBundleResourceKindKubernetesCluster
+	version := kubernetesClusterApplicationBundleVersion
+
+	bundle := &unikornv1.ApplicationBundle{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: kubernetesClusterApplicationBundleName,
+		},
+		Spec: unikornv1.ApplicationBundleSpec{
+			Kind:    &kind,
+			Version: &version,
+		},
+	}
+
+	assert.NilError(t, tc.KubernetesClient().Create(context.TODO(), bundle, &client.CreateOptions{}))
 }

--- a/pkg/testutil/assert/assert.go
+++ b/pkg/testutil/assert/assert.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package testutil
+package assert
 
 import (
 	"errors"
@@ -22,8 +22,8 @@ import (
 	"testing"
 )
 
-// AssertEqual is a terse way of checking some assumption holds, offing itself if it doesn't.
-func AssertEqual[T comparable](t *testing.T, expected, actual T) {
+// Equal is a terse way of checking some assumption holds, offing itself if it doesn't.
+func Equal[T comparable](t *testing.T, expected, actual T) {
 	t.Helper()
 
 	if expected != actual {
@@ -31,8 +31,8 @@ func AssertEqual[T comparable](t *testing.T, expected, actual T) {
 	}
 }
 
-// AssertNotEqual is a terse way of checking some assumption doesn't hold, offing itself if it does.
-func AssertNotEqual[T comparable](t *testing.T, expected, actual T) {
+// NotEqual is a terse way of checking some assumption doesn't hold, offing itself if it does.
+func NotEqual[T comparable](t *testing.T, expected, actual T) {
 	t.Helper()
 
 	if expected == actual {
@@ -40,8 +40,8 @@ func AssertNotEqual[T comparable](t *testing.T, expected, actual T) {
 	}
 }
 
-// AssertNilError is a terse way of crapping out if an error occurred.
-func AssertNilError(t *testing.T, err error) {
+// NilError is a terse way of crapping out if an error occurred.
+func NilError(t *testing.T, err error) {
 	t.Helper()
 
 	if err != nil {
@@ -49,8 +49,8 @@ func AssertNilError(t *testing.T, err error) {
 	}
 }
 
-// AssertNotNil is a terse way of crapping out if a pointer is nil.
-func AssertNotNil[T any](t *testing.T, v *T) {
+// NotNil is a terse way of crapping out if a pointer is nil.
+func NotNil[T any](t *testing.T, v *T) {
 	t.Helper()
 
 	if v == nil {
@@ -58,8 +58,21 @@ func AssertNotNil[T any](t *testing.T, v *T) {
 	}
 }
 
-// AssertError is a terse way of crapping out if an error didn't occur.
-func AssertError(t *testing.T, expected, err error) {
+// MapSet checks a map exists, and also that the named key is present.
+func MapSet[T any](t *testing.T, m map[string]T, key string) {
+	t.Helper()
+
+	if m == nil {
+		t.Fatalf("assertion failure: map undefined")
+	}
+
+	if _, ok := m[key]; !ok {
+		t.Fatalf("assertion failure: missing map key %s", key)
+	}
+}
+
+// Error is a terse way of crapping out if an error didn't occur.
+func Error(t *testing.T, expected, err error) {
 	t.Helper()
 
 	if err == nil {
@@ -71,8 +84,8 @@ func AssertError(t *testing.T, expected, err error) {
 	}
 }
 
-// AssertKubernetesError is a terse way of crapping out if an error didn't occur.
-func AssertKubernetesError(t *testing.T, callback func(error) bool, err error) {
+// KubernetesError is a terse way of crapping out if an error didn't occur.
+func KubernetesError(t *testing.T, callback func(error) bool, err error) {
 	t.Helper()
 
 	if err == nil {
@@ -84,11 +97,11 @@ func AssertKubernetesError(t *testing.T, callback func(error) bool, err error) {
 	}
 }
 
-// AssertHTTPResponse is a terse way of crapping out when the response is not
+// HTTPResponse is a terse way of crapping out when the response is not
 // as intended.
-func AssertHTTPResponse(t *testing.T, response *http.Response, statusCode int, err error) {
+func HTTPResponse(t *testing.T, response *http.Response, statusCode int, err error) {
 	t.Helper()
 
-	AssertNilError(t, err)
-	AssertEqual(t, statusCode, response.StatusCode)
+	NilError(t, err)
+	Equal(t, statusCode, response.StatusCode)
 }


### PR DESCRIPTION
Adds in deep inspection of get/list for Unikorn types, in order to test the fixtures are working before we get on to the negative tests.  Bunch of debug enhancements and general cleanup.