### PR TITLE
Implicit Child Object Creation

### DIFF
--- a/pkg/managers/cluster/reconcile.go
+++ b/pkg/managers/cluster/reconcile.go
@@ -95,7 +95,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	// Check to see if this is (or appears to be) the first time we've seen a
 	// resource and do observability as appropriate.
-	if err := r.handleReconcileFirstVisit(ctx, object); err != nil {
+	if err := r.addFinalizer(ctx, object); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -105,63 +105,37 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	provisionContext, cancel := context.WithTimeout(ctx, object.Spec.Timeout.Duration)
 	defer cancel()
 
-	if err := provisioner.Provision(provisionContext); err != nil {
-		// If the provisioner has voluntarily yielded, requeue it and look at
-		// it later to allow others to use the worker, or indeed pickup delete
-		// requests, updates... probably not a great idea :D
-		// NOTE: DO NOT do what CAPI do and not-specify a wait period, it will
-		// suffer from an exponential back-off and kill performance.
-		if errors.Is(err, provisionererrors.ErrYield) {
-			log.Info("reconcile yielding")
+	perr := provisioner.Provision(provisionContext)
 
-			return reconcile.Result{RequeueAfter: constants.DefaultYieldTimeout}, nil
-		}
-
-		if err := r.handleReconcileError(ctx, object, err); err != nil {
-			return reconcile.Result{}, err
-		}
-
+	// Update the status conditionally, this will remove transient errors etc.
+	if err := r.handleReconcileCondition(ctx, object, perr); err != nil {
 		return reconcile.Result{}, err
 	}
 
-	if err := r.handleReconcileComplete(ctx, object); err != nil {
-		return reconcile.Result{}, err
+	// If anything went wrong, requeue for another attempt.
+	// NOTE: DO NOT do what CAPI do and not-specify a wait period, it will
+	// suffer from an exponential back-off and kill performance.
+	if perr != nil {
+		//nolint:nilerr
+		return reconcile.Result{RequeueAfter: constants.DefaultYieldTimeout}, nil
 	}
 
 	return reconcile.Result{}, nil
 }
 
-// handleReconcileFirstVisit checks to see if the Available condition is present in the
-// status, if not we assume it's the first time we've seen this an set the condition to
-// Provisioning.
-func (r *reconciler) handleReconcileFirstVisit(ctx context.Context, kubernetesCluster *unikornv1.KubernetesCluster) error {
-	condition, err := kubernetesCluster.LookupCondition(unikornv1.KubernetesClusterConditionAvailable)
-	if err != nil {
-		kubernetesCluster.Finalizers = []string{
-			constants.Finalizer,
+// addFinalizer looks to see if we've seen this resource yet, and adds a finalizer so
+// we can orchestrate deletion correctly.
+func (r *reconciler) addFinalizer(ctx context.Context, resource *unikornv1.KubernetesCluster) error {
+	for _, finalizer := range resource.Finalizers {
+		if finalizer == constants.Finalizer {
+			return nil
 		}
-
-		if err := r.client.Update(ctx, kubernetesCluster); err != nil {
-			return err
-		}
-
-		kubernetesCluster.UpdateAvailableCondition(corev1.ConditionFalse, unikornv1.KubernetesClusterConditionReasonProvisioning, "Provisioning kubernetes cluster")
-
-		if err := r.client.Status().Update(ctx, kubernetesCluster); err != nil {
-			return err
-		}
-
-		return nil
 	}
 
-	if condition.Reason == unikornv1.KubernetesClusterConditionReasonProvisioned {
-		kubernetesCluster.UpdateAvailableCondition(corev1.ConditionTrue, unikornv1.KubernetesClusterConditionReasonUpdating, "Updating control plane")
+	resource.Finalizers = append(resource.Finalizers, constants.Finalizer)
 
-		if err := r.client.Status().Update(ctx, kubernetesCluster); err != nil {
-			return err
-		}
-
-		return nil
+	if err := r.client.Update(ctx, resource); err != nil {
+		return err
 	}
 
 	return nil
@@ -178,38 +152,39 @@ func (r *reconciler) handleReconcileDeprovision(ctx context.Context, kubernetesC
 	return nil
 }
 
-// handleReconcileComplete indicates that the reconcile is complete and the control
-// plane is ready to be used.
-func (r *reconciler) handleReconcileComplete(ctx context.Context, kubernetesCluster *unikornv1.KubernetesCluster) error {
-	if ok := kubernetesCluster.UpdateAvailableCondition(corev1.ConditionTrue, unikornv1.KubernetesClusterConditionReasonProvisioned, "Provisioning of kubernetes cluster has completed"); ok {
-		if err := r.client.Status().Update(ctx, kubernetesCluster); err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
-// handleReconcileError inspects the error type that halted the provisioning and reports
+// handleReconcileCondition inspects the error, if any, that halted the provisioning and reports
 // this as a ppropriate in the status.
-func (r *reconciler) handleReconcileError(ctx context.Context, kubernetesCluster *unikornv1.KubernetesCluster, err error) error {
+func (r *reconciler) handleReconcileCondition(ctx context.Context, kubernetesCluster *unikornv1.KubernetesCluster, err error) error {
+	var status corev1.ConditionStatus
+
 	var reason unikornv1.KubernetesClusterConditionReason
 
 	var message string
 
 	switch {
+	case err == nil:
+		status = corev1.ConditionTrue
+		reason = unikornv1.KubernetesClusterConditionReasonProvisioned
+		message = "Provisioned"
+	case errors.Is(err, provisionererrors.ErrYield):
+		status = corev1.ConditionFalse
+		reason = unikornv1.KubernetesClusterConditionReasonProvisioning
+		message = "Provisioning"
 	case errors.Is(err, context.Canceled):
+		status = corev1.ConditionFalse
 		reason = unikornv1.KubernetesClusterConditionReasonCanceled
-		message = "Provisioning aborted due to controller shudown"
+		message = "Aborted due to controller shudown"
 	case errors.Is(err, context.DeadlineExceeded):
+		status = corev1.ConditionFalse
 		reason = unikornv1.KubernetesClusterConditionReasonTimedout
-		message = fmt.Sprintf("Provisioning aborted due to a timeout: %v", err)
+		message = fmt.Sprintf("Aborted due to a timeout: %v", err)
 	default:
+		status = corev1.ConditionFalse
 		reason = unikornv1.KubernetesClusterConditionReasonErrored
-		message = fmt.Sprintf("Provisioning failed due to an error: %v", err)
+		message = fmt.Sprintf("Failed due to an error: %v", err)
 	}
 
-	if ok := kubernetesCluster.UpdateAvailableCondition(corev1.ConditionFalse, reason, message); ok {
+	if ok := kubernetesCluster.UpdateAvailableCondition(status, reason, message); ok {
 		if err := r.client.Status().Update(ctx, kubernetesCluster); err != nil {
 			return err
 		}

--- a/pkg/provisioners/conditional/provisioner.go
+++ b/pkg/provisioners/conditional/provisioner.go
@@ -25,8 +25,7 @@ import (
 )
 
 type Provisioner struct {
-	// name is the conditional name.
-	name string
+	provisioners.ProvisionerMeta
 
 	// condition will execute the provisioner if true.
 	condition func() bool
@@ -37,7 +36,9 @@ type Provisioner struct {
 
 func New(name string, condition func() bool, provisioner provisioners.Provisioner) *Provisioner {
 	return &Provisioner{
-		name:        name,
+		ProvisionerMeta: provisioners.ProvisionerMeta{
+			Name: name,
+		},
 		condition:   condition,
 		provisioner: provisioner,
 	}
@@ -51,7 +52,7 @@ func (p *Provisioner) Provision(ctx context.Context) error {
 	log := log.FromContext(ctx)
 
 	if !p.condition() {
-		log.Info("conditional deprovision", "provisioner", p.name)
+		log.Info("conditional deprovision", "provisioner", p.Name)
 
 		return p.provisioner.Deprovision(ctx)
 	}
@@ -64,7 +65,7 @@ func (p *Provisioner) Deprovision(ctx context.Context) error {
 	log := log.FromContext(ctx)
 
 	if !p.condition() {
-		log.Info("skipping conditional deprovision", "provisioner", p.name)
+		log.Info("skipping conditional deprovision", "provisioner", p.Name)
 
 		return nil
 	}

--- a/pkg/provisioners/generic/kubectl.go
+++ b/pkg/provisioners/generic/kubectl.go
@@ -36,6 +36,8 @@ import (
 // TODO: some manifests may not have a namspace, we may want to allow
 // overriding this.
 type KubectlProvisioner struct {
+	provisioners.ProvisionerMeta
+
 	// config allows access to the provided kubeconfig, context etc.
 	// TODO: this is not aware of ClientConfigLoadingRules so environment
 	// variables will be ignored for now.

--- a/pkg/provisioners/generic/resource.go
+++ b/pkg/provisioners/generic/resource.go
@@ -33,6 +33,8 @@ import (
 // ResourceProvisioner is a provisioner that is able to parse and manage resources
 // sourced from a yaml manifest.
 type ResourceProvisioner struct {
+	provisioners.ProvisionerMeta
+
 	// client is a client to allow Kubernetes access.
 	client client.Client
 

--- a/pkg/provisioners/helmapplications/clusteropenstack/provisioner.go
+++ b/pkg/provisioners/helmapplications/clusteropenstack/provisioner.go
@@ -37,6 +37,8 @@ const (
 
 // Provisioner encapsulates control plane provisioning.
 type Provisioner struct {
+	provisioners.ProvisionerMeta
+
 	// client provides access to Kubernetes.
 	client client.Client
 
@@ -69,6 +71,9 @@ func New(ctx context.Context, client client.Client, cluster *unikornv1.Kubernete
 	}
 
 	provisioner := &Provisioner{
+		ProvisionerMeta: provisioners.ProvisionerMeta{
+			Name: cluster.Name,
+		},
 		client:             client,
 		cluster:            cluster,
 		controlPlanePrefix: controlPlanePrefix,

--- a/pkg/provisioners/interfaces.go
+++ b/pkg/provisioners/interfaces.go
@@ -46,6 +46,9 @@ type RemoteCluster interface {
 // packages in a technology agnostic way.  For example some things may be
 // installed as a raw set of resources, a YAML manifest, Helm etc.
 type Provisioner interface {
+	// ProvisionerName returns the provisioner name.
+	ProvisionerName() string
+
 	// Provision deploys the requested package.
 	// Implementations should ensure this receiver is idempotent.
 	Provision(context.Context) error

--- a/pkg/provisioners/managers/cluster/provisioner.go
+++ b/pkg/provisioners/managers/cluster/provisioner.go
@@ -47,6 +47,8 @@ import (
 
 // Provisioner encapsulates control plane provisioning.
 type Provisioner struct {
+	provisioners.ProvisionerMeta
+
 	// client provides access to Kubernetes.
 	client client.Client
 

--- a/pkg/provisioners/managers/project/provisioner.go
+++ b/pkg/provisioners/managers/project/provisioner.go
@@ -37,6 +37,8 @@ var (
 
 // Provisioner encapsulates control plane provisioning.
 type Provisioner struct {
+	provisioners.ProvisionerMeta
+
 	// client provides access to Kubernetes.
 	client client.Client
 

--- a/pkg/provisioners/types.go
+++ b/pkg/provisioners/types.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2022-2023 EscherCloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provisioners
+
+// ProvisionerMeta is a container for geneirc provisioner metadata.
+type ProvisionerMeta struct {
+	// Name is the name of the provisioner.
+	Name string
+}
+
+// ProvisionerName implements the Provisioner interface.
+func (p *ProvisionerMeta) ProvisionerName() string {
+	return p.Name
+}

--- a/pkg/server/handler/cluster/client.go
+++ b/pkg/server/handler/cluster/client.go
@@ -246,8 +246,8 @@ func (c *Client) Create(ctx context.Context, controlPlaneName generated.ControlP
 		return err
 	}
 
-	if !controlPlane.Active {
-		return errors.OAuth2InvalidRequest("control plane is not active")
+	if controlPlane.Deleting {
+		return errors.OAuth2InvalidRequest("control plane is being deleted")
 	}
 
 	cluster, err := c.createCluster(controlPlane, options)
@@ -301,8 +301,8 @@ func (c *Client) Delete(ctx context.Context, controlPlaneName generated.ControlP
 		return err
 	}
 
-	if !controlPlane.Active {
-		return errors.OAuth2InvalidRequest("control plane is not active")
+	if controlPlane.Deleting {
+		return errors.OAuth2InvalidRequest("control plane is being deleted")
 	}
 
 	cluster := &unikornv1.KubernetesCluster{
@@ -330,8 +330,8 @@ func (c *Client) Update(ctx context.Context, controlPlaneName generated.ControlP
 		return err
 	}
 
-	if !controlPlane.Active {
-		return errors.OAuth2InvalidRequest("control plane is not active")
+	if controlPlane.Deleting {
+		return errors.OAuth2InvalidRequest("control plane is being deleted")
 	}
 
 	resource, err := c.get(ctx, controlPlane.Namespace, name)

--- a/pkg/server/options.go
+++ b/pkg/server/options.go
@@ -39,7 +39,9 @@ type Options struct {
 
 	// WriteTimeout defines how long we take to respond before we give up.
 	// Ideally we'd like this to be short, but Openstack in general sucks
-	// for performance.
+	// for performance.  Additionally some calls like cluster creation can
+	// do a cascading create, e.g. create a default control plane, than in
+	// turn creates a project.
 	WriteTimeout time.Duration
 
 	// OTLPEndpoint defines whether to ship spans to an OTLP consumer or


### PR DESCRIPTION
At present, a client needs to create a project, wait, create a control plane, wait, then create a cluster.  Theoretically it should be possible to create a cluster, have it create a default control plane, wait only as long as it takes to provision the namespace and yield, etc.

Theory and practice are very different though, with the main "simple" bit done, it revealed that waiting is subtly flawed in that there is always a delay before the first tick, so that needs fixing from a performance standpoint.  Next there is a race where cluster creation fails with an error due to CRD installation racing against machine delployment cleanup.  This leads to the cluster getting stuck in an error state.  This is now fixed so the error is transient, but does require the core of all the managers to be ripped out and replaced. Tracking down that issue in the first place required a whole heap of extra debug code, which should have some benefits down the line, I had been meaning to do something of that ilk.

Fixes #249