### PR TITLE
Tweak Finalizers

### DIFF
--- a/pkg/managers/controlplane/reconcile.go
+++ b/pkg/managers/controlplane/reconcile.go
@@ -24,6 +24,7 @@ import (
 
 	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
 	"github.com/eschercloudai/unikorn/pkg/constants"
+	"github.com/eschercloudai/unikorn/pkg/provisioners"
 	provisionererrors "github.com/eschercloudai/unikorn/pkg/provisioners/errors"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/managers/controlplane"
 
@@ -31,6 +32,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -41,7 +43,6 @@ type reconciler struct {
 
 var _ reconcile.Reconciler = &reconciler{}
 
-//nolint:cyclop
 func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
 	log := log.FromContext(ctx)
 
@@ -63,40 +64,26 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, err
 	}
 
-	// If it's being deleted, ignore it, we don't need to take any additional action.
+	// If it's being deleted, ignore if there are no finalizers, Kubernetes is in
+	// charge now.  If the finalizer is still in place, run the deprovisioning.
 	if object.DeletionTimestamp != nil {
 		if len(object.Finalizers) == 0 {
 			return reconcile.Result{}, nil
 		}
 
-		log.Info("resource deleting")
+		log.Info("deleting resource")
 
-		if err := r.handleReconcileDeprovision(ctx, object); err != nil {
-			return reconcile.Result{}, err
-		}
-
-		timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
-		defer cancel()
-
-		if err := provisioner.Deprovision(timeoutCtx); err != nil {
-			return reconcile.Result{}, err
-		}
-
-		object.Finalizers = nil
-
-		if err := r.client.Update(ctx, object); err != nil {
-			return reconcile.Result{}, err
-		}
-
-		return reconcile.Result{}, nil
+		return r.reconcileDelete(ctx, provisioner, object)
 	}
 
 	log.V(1).Info("reconciling resource")
 
 	// Check to see if this is (or appears to be) the first time we've seen a
 	// resource and do observability as appropriate.
-	if err := r.addFinalizer(ctx, object); err != nil {
-		return reconcile.Result{}, err
+	if ok := controllerutil.AddFinalizer(object, constants.Finalizer); ok {
+		if err := r.client.Update(ctx, object); err != nil {
+			return reconcile.Result{}, err
+		}
 	}
 
 	// Create a new context with a status object attached, we'll use this later to
@@ -123,33 +110,28 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	return reconcile.Result{}, nil
 }
 
-// addFinalizer looks to see if we've seen this resource yet, and adds a finalizer so
-// we can orchestrate deletion correctly.
-func (r *reconciler) addFinalizer(ctx context.Context, resource *unikornv1.ControlPlane) error {
-	for _, finalizer := range resource.Finalizers {
-		if finalizer == constants.Finalizer {
-			return nil
+// reconcileDelete handles resource deletion.
+func (r *reconciler) reconcileDelete(ctx context.Context, provisioner provisioners.Provisioner, resource *unikornv1.ControlPlane) (reconcile.Result, error) {
+	if ok := resource.UpdateAvailableCondition(corev1.ConditionFalse, unikornv1.ControlPlaneConditionReasonDeprovisioning, "Deprovisioning"); ok {
+		if err := r.client.Status().Update(ctx, resource); err != nil {
+			return reconcile.Result{}, err
 		}
 	}
 
-	resource.Finalizers = append(resource.Finalizers, constants.Finalizer)
+	timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+	defer cancel()
 
-	if err := r.client.Update(ctx, resource); err != nil {
-		return err
+	if err := provisioner.Deprovision(timeoutCtx); err != nil {
+		return reconcile.Result{}, err
 	}
 
-	return nil
-}
-
-// handleReconcileDeprovision indicates the deprovision request has been picked up.
-func (r *reconciler) handleReconcileDeprovision(ctx context.Context, controlPlane *unikornv1.ControlPlane) error {
-	if ok := controlPlane.UpdateAvailableCondition(corev1.ConditionFalse, unikornv1.ControlPlaneConditionReasonDeprovisioning, "Control plane is being deprovisioned"); ok {
-		if err := r.client.Status().Update(ctx, controlPlane); err != nil {
-			return err
+	if ok := controllerutil.RemoveFinalizer(resource, constants.Finalizer); ok {
+		if err := r.client.Update(ctx, resource); err != nil {
+			return reconcile.Result{}, err
 		}
 	}
 
-	return nil
+	return reconcile.Result{}, nil
 }
 
 // handleReconcileCondition inspects the error, if any, that halted the provisioning and reports

--- a/pkg/provisioners/application/provisioner.go
+++ b/pkg/provisioners/application/provisioner.go
@@ -413,6 +413,7 @@ func (p *Provisioner) Provision(ctx context.Context) error {
 		}
 	}
 
+	// TODO: can probably just use controllerutil.CreateOrPatch.
 	//nolint:nestif
 	if resource == nil {
 		log.Info("creating new application", "application", p.Name)

--- a/pkg/provisioners/managers/project/provisioner.go
+++ b/pkg/provisioners/managers/project/provisioner.go
@@ -110,19 +110,6 @@ func (p *Provisioner) Deprovision(ctx context.Context) error {
 		return err
 	}
 
-	// Find any control planes and delete them.  They in turn will delete clusters and
-	// free any Openstack resources.
-	controlPlanes := &unikornv1alpha1.ControlPlaneList{}
-	if err := p.client.List(ctx, controlPlanes, &client.ListOptions{Namespace: namespace.Name}); err != nil {
-		return err
-	}
-
-	for i := range controlPlanes.Items {
-		if err := generic.NewResourceProvisioner(p.client, &controlPlanes.Items[i]).Deprovision(ctx); err != nil {
-			return err
-		}
-	}
-
 	// Deprovision the namespace and await deletion.
 	if err := generic.NewResourceProvisioner(p.client, namespace).Deprovision(ctx); err != nil {
 		return err


### PR DESCRIPTION
There's a couple library functions we can use to move towards more generic reconcilers, rather than reinventing the wheel.  Also, while exploring other possibilities I noted that the project provisioner is overly complex when it doesn't need to be, so removed some crud.