### PR TITLE
Non-Blocking Deletion

### DIFF
--- a/pkg/managers/controlplane/reconcile.go
+++ b/pkg/managers/controlplane/reconcile.go
@@ -25,7 +25,6 @@ import (
 	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
 	"github.com/eschercloudai/unikorn/pkg/constants"
 	"github.com/eschercloudai/unikorn/pkg/provisioners"
-	provisionererrors "github.com/eschercloudai/unikorn/pkg/provisioners/errors"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/managers/controlplane"
 
 	corev1 "k8s.io/api/core/v1"
@@ -122,6 +121,10 @@ func (r *reconciler) reconcileDelete(ctx context.Context, provisioner provisione
 	defer cancel()
 
 	if err := provisioner.Deprovision(timeoutCtx); err != nil {
+		if errors.Is(err, provisioners.ErrYield) {
+			return reconcile.Result{RequeueAfter: constants.DefaultYieldTimeout}, nil
+		}
+
 		return reconcile.Result{}, err
 	}
 
@@ -148,7 +151,7 @@ func (r *reconciler) handleReconcileCondition(ctx context.Context, controlPlane 
 		status = corev1.ConditionTrue
 		reason = unikornv1.ControlPlaneConditionReasonProvisioned
 		message = "Provisioning has completed"
-	case errors.Is(err, provisionererrors.ErrYield):
+	case errors.Is(err, provisioners.ErrYield):
 		status = corev1.ConditionFalse
 		reason = unikornv1.ControlPlaneConditionReasonProvisioning
 		message = "Provisioning"

--- a/pkg/managers/project/reconcile.go
+++ b/pkg/managers/project/reconcile.go
@@ -111,6 +111,10 @@ func (r *reconciler) reconcileDelete(ctx context.Context, provisioner provisione
 	defer cancel()
 
 	if err := provisioner.Deprovision(timeoutCtx); err != nil {
+		if errors.Is(err, provisioners.ErrYield) {
+			return reconcile.Result{RequeueAfter: constants.DefaultYieldTimeout}, nil
+		}
+
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/provisioners/errors.go
+++ b/pkg/provisioners/errors.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package errors
+package provisioners
 
 import (
 	"errors"

--- a/pkg/provisioners/helmapplications/clusteropenstack/remotecluster.go
+++ b/pkg/provisioners/helmapplications/clusteropenstack/remotecluster.go
@@ -24,7 +24,6 @@ import (
 	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
 	"github.com/eschercloudai/unikorn/pkg/constants"
 	"github.com/eschercloudai/unikorn/pkg/provisioners"
-	provisionererrors "github.com/eschercloudai/unikorn/pkg/provisioners/errors"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -120,7 +119,7 @@ func (g *RemoteClusterGenerator) Config(ctx context.Context) (*clientcmdapi.Conf
 		if errors.IsNotFound(err) {
 			log.Info("kubernetes cluster kubeconfig does not exist, yielding")
 
-			return nil, provisionererrors.ErrYield
+			return nil, provisioners.ErrYield
 		}
 
 		return nil, err

--- a/pkg/provisioners/helmapplications/vcluster/config.go
+++ b/pkg/provisioners/helmapplications/vcluster/config.go
@@ -22,7 +22,7 @@ import (
 	"io"
 	"os"
 
-	provisionererrors "github.com/eschercloudai/unikorn/pkg/provisioners/errors"
+	"github.com/eschercloudai/unikorn/pkg/provisioners"
 
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -109,7 +109,7 @@ func (c *ControllerRuntimeClient) GetSecret(ctx context.Context, namespace, name
 		if kerrors.IsNotFound(err) {
 			log.Info("vitual cluster kubeconfig does not exist, yielding")
 
-			return nil, provisionererrors.ErrYield
+			return nil, provisioners.ErrYield
 		}
 
 		return nil, err

--- a/pkg/provisioners/remotecluster/provisioner.go
+++ b/pkg/provisioners/remotecluster/provisioner.go
@@ -23,7 +23,6 @@ import (
 	argocdclient "github.com/eschercloudai/unikorn/pkg/argocd/client"
 	argocdcluster "github.com/eschercloudai/unikorn/pkg/argocd/cluster"
 	"github.com/eschercloudai/unikorn/pkg/provisioners"
-	provisionererrors "github.com/eschercloudai/unikorn/pkg/provisioners/errors"
 
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -118,7 +117,7 @@ func (p *Provisioner) Provision(ctx context.Context) error {
 	if err := argocdcluster.Upsert(ctx, argocd, p.Name, server, config); err != nil {
 		log.Info("remote cluster not ready, yielding", "remotecluster", p.Name)
 
-		return provisionererrors.ErrYield
+		return provisioners.ErrYield
 	}
 
 	log.Info("remote cluster provisioned", "remotecluster", p.Name)


### PR DESCRIPTION
Deletion was previously blocking, as it would wait on certain operations, this can last to long running reconciles that block other requests and can cause starvation.  In much the same way as provisioning works, rather than wait, yield and let any waits happen due to reconcile retries, thus allowing other users to have a go.

Fixes #279