### PR TITLE
Use Google Distroless Images

### DIFF
--- a/docker/unikorn-cluster-manager/Dockerfile
+++ b/docker/unikorn-cluster-manager/Dockerfile
@@ -1,20 +1,8 @@
-FROM ubuntu:jammy as base
-
-RUN apt update \
- && apt -y install ca-certificates
-
-FROM scratch
+FROM gcr.io/distroless/static:nonroot
 
 # This is implcitly created by 'docker buildx build'
 ARG TARGETARCH
 
-# Required by the SNAT hack, so CAPI can talk to Kubernetes when a firewall
-# is placed in the way.
-COPY --from=base /etc/ssl/certs/ca-certificates.crt /ca-certificates.crt
 COPY bin/${TARGETARCH}-linux-gnu/unikorn-cluster-manager /
-COPY hack/passwd.nonroot /etc/passwd
-
-ENV SSL_CERT_FILE=/ca-certificates.crt
-USER 1000
 
 ENTRYPOINT ["/unikorn-cluster-manager"]

--- a/docker/unikorn-control-plane-manager/Dockerfile
+++ b/docker/unikorn-control-plane-manager/Dockerfile
@@ -1,11 +1,8 @@
-FROM scratch
+FROM gcr.io/distroless/static:nonroot
 
 # This is implcitly created by 'docker buildx build'
 ARG TARGETARCH
 
 COPY bin/${TARGETARCH}-linux-gnu/unikorn-control-plane-manager /
-COPY hack/passwd.nonroot /etc/passwd
-
-USER 1000
 
 ENTRYPOINT ["/unikorn-control-plane-manager"]

--- a/docker/unikorn-monitor/Dockerfile
+++ b/docker/unikorn-monitor/Dockerfile
@@ -1,11 +1,8 @@
-FROM scratch
+FROM gcr.io/distroless/static:nonroot
 
 # This is implcitly created by 'docker buildx build'
 ARG TARGETARCH
 
 COPY bin/${TARGETARCH}-linux-gnu/unikorn-monitor /
-COPY hack/passwd.nonroot /etc/passwd
-
-USER 1000
 
 ENTRYPOINT ["/unikorn-monitor"]

--- a/docker/unikorn-project-manager/Dockerfile
+++ b/docker/unikorn-project-manager/Dockerfile
@@ -1,11 +1,8 @@
-FROM scratch
+FROM gcr.io/distroless/static:nonroot
 
 # This is implcitly created by 'docker buildx build'
 ARG TARGETARCH
 
 COPY bin/${TARGETARCH}-linux-gnu/unikorn-project-manager /
-COPY hack/passwd.nonroot /etc/passwd
-
-USER 1000
 
 ENTRYPOINT ["/unikorn-project-manager"]

--- a/docker/unikorn-server/Dockerfile
+++ b/docker/unikorn-server/Dockerfile
@@ -1,19 +1,9 @@
-FROM ubuntu:jammy as base
-
-RUN apt update \
- && apt -y install ca-certificates
-
-FROM scratch
+FROM gcr.io/distroless/static:nonroot
 
 # This is implcitly created by 'docker buildx build'
 ARG TARGETARCH
 
 # Required as we are talking to Openstack public endpoints.
-COPY --from=base /etc/ssl/certs/ca-certificates.crt /ca-certificates.crt
 COPY bin/${TARGETARCH}-linux-gnu/unikorn-server /
-COPY hack/passwd.nonroot /etc/passwd
-
-ENV SSL_CERT_FILE=/ca-certificates.crt
-USER 1000
 
 ENTRYPOINT ["/unikorn-server"]

--- a/hack/passwd.nonroot
+++ b/hack/passwd.nonroot
@@ -1,1 +1,0 @@
-unikorn:x:1000:1000:Unikorn Non Root,,,::


### PR DESCRIPTION
They do things like install a non-root user and CA certificates for us, which is always a benefit.  This should reduce build times somewhat due to no, or very little, emulation involved other than copying a binary.