### PR TITLE
Remove Cluster 1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Consult the [developer documentation](DEVELOPER.md) for local development instru
 Download the official binary (update the version as appropriate):
 
 ```shell
-wget -O ~/bin/unikornctl https://github.com/eschercloudai/unikorn/releases/download/0.3.48/unikornctl-linux-amd64
+wget -O ~/bin/unikornctl https://github.com/eschercloudai/unikorn/releases/download/0.3.50/unikornctl-linux-amd64
 ```
 
 ### Set up shell completion
@@ -232,7 +232,7 @@ spec:
   source:
     path: charts/unikorn
     repoURL: git@github.com:eschercloudai/unikorn
-    targetRevision: 0.3.49
+    targetRevision: 0.3.50
     helm:
       parameters:
       - name: dockerConfig

--- a/charts/unikorn/Chart.yaml
+++ b/charts/unikorn/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for deploying Unikorn
 
 type: application
 
-version: 0.3.49
-appVersion: 0.3.49
+version: 0.3.50
+appVersion: 0.3.50
 
 icon: https://raw.githubusercontent.com/eschercloudai/unikorn/main/icons/default.png

--- a/charts/unikorn/templates/applicationbundles.yaml
+++ b/charts/unikorn/templates/applicationbundles.yaml
@@ -44,72 +44,6 @@ spec:
 apiVersion: unikorn.eschercloud.ai/v1alpha1
 kind: ApplicationBundle
 metadata:
-  name: kubernetes-cluster-1.3.0
-spec:
-  kind: KubernetesCluster
-  version: 1.3.0
-  applications:
-  - name: cluster-openstack
-    reference:
-      kind: HelmApplication
-      name: cluster-openstack-0.3.24-1
-  - name: cilium
-    reference:
-      kind: HelmApplication
-      name: cilium-1.13.3-1
-  - name: openstack-cloud-provider
-    reference:
-      kind: HelmApplication
-      name: openstack-cloud-provider-1.4.0-1
-  - name: openstack-plugin-cinder-csi
-    reference:
-      kind: HelmApplication
-      name: openstack-plugin-cinder-csi-2.3.0-1
-  - name: metrics-server
-    reference:
-      kind: HelmApplication
-      name: metrics-server-3.8.4-1
-  - name: nginx-ingress
-    reference:
-      kind: HelmApplication
-      name: ingress-nginx-4.6.1-1
-  - name: cluster-autoscaler
-    reference:
-      kind: HelmApplication
-      name: cluster-autoscaler-1.27.1-1
-  - name: cluster-autoscaler-openstack
-    reference:
-      kind: HelmApplication
-      name: cluster-autoscaler-openstack-0.1.0-1
-  - name: nvidia-gpu-operator
-    reference:
-      kind: HelmApplication
-      name: nvidia-gpu-operator-23.3.1-1
-  - name: cert-manager
-    reference:
-      kind: HelmApplication
-      name: cert-manager-1.11.0-1
-  - name: cert-manager-issuers
-    reference:
-      kind: HelmApplication
-      name: cert-manager-issuers-1.0.0-1
-  - name: kubernetes-dashboard
-    reference:
-      kind: HelmApplication
-      name: kubernetes-dashboard-6.0.7-1
-  - name: longhorn
-    reference:
-      kind: HelmApplication
-      name: longhorn-1.4.2-1
-  - name: prometheus
-    reference:
-      kind: HelmApplication
-      name: kube-prometheus-stack-46.8.0-1
-
----
-apiVersion: unikorn.eschercloud.ai/v1alpha1
-kind: ApplicationBundle
-metadata:
   name: kubernetes-cluster-1.3.1
 spec:
   kind: KubernetesCluster
@@ -171,7 +105,6 @@ spec:
     reference:
       kind: HelmApplication
       name: kube-prometheus-stack-46.8.0-1
-
 ---
 apiVersion: unikorn.eschercloud.ai/v1alpha1
 kind: ApplicationBundle

--- a/charts/unikorn/templates/applications.yaml
+++ b/charts/unikorn/templates/applications.yaml
@@ -110,17 +110,6 @@ spec:
 apiVersion: unikorn.eschercloud.ai/v1alpha1
 kind: HelmApplication
 metadata:
-  name: cluster-openstack-0.3.24-1
-spec:
-  repo: https://eschercloudai.github.io/helm-cluster-api
-  chart: cluster-api-cluster-openstack
-  version: v0.3.24
-  createNamespace: true
-  interface: 1.0.0
----
-apiVersion: unikorn.eschercloud.ai/v1alpha1
-kind: HelmApplication
-metadata:
   name: cluster-openstack-0.3.25-1
 spec:
   repo: https://eschercloudai.github.io/helm-cluster-api


### PR DESCRIPTION
With CAPO 0.8.0 impending, we want all clusters up to the latest head so we don't have to either create branches, or introduce impacting changes at the same time as this major upgrade.  Luckily, all clusters in production are at 1.3.1, so we can kill this and avoid the problem altogether.