### PR TITLE
Application Inference

### DIFF
--- a/pkg/apis/unikorn/v1alpha1/helpers.go
+++ b/pkg/apis/unikorn/v1alpha1/helpers.go
@@ -162,6 +162,10 @@ func (c *ControlPlane) ResourceLabels() (labels.Set, error) {
 	return labels, nil
 }
 
+func (c *ControlPlane) ApplicationBundleKind() ApplicationBundleResourceKind {
+	return ApplicationBundleResourceKindControlPlane
+}
+
 func (c *ControlPlane) ApplicationBundleName() string {
 	return *c.Spec.ApplicationBundle
 }
@@ -208,6 +212,10 @@ func (c *KubernetesCluster) ResourceLabels() (labels.Set, error) {
 	}
 
 	return labels, nil
+}
+
+func (c *KubernetesCluster) ApplicationBundleKind() ApplicationBundleResourceKind {
+	return ApplicationBundleResourceKindKubernetesCluster
 }
 
 func (c *KubernetesCluster) ApplicationBundleName() string {

--- a/pkg/provisioners/helmapplications/certmanager/provisioner.go
+++ b/pkg/provisioners/helmapplications/certmanager/provisioner.go
@@ -17,7 +17,6 @@ limitations under the License.
 package certmanager
 
 import (
-	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
 	"github.com/eschercloudai/unikorn/pkg/cd"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/application"
 )
@@ -28,8 +27,8 @@ const (
 )
 
 // New returns a new initialized provisioner object.
-func New(driver cd.Driver, resource application.MutuallyExclusiveResource, helm *unikornv1.HelmApplication) *application.Provisioner {
+func New(driver cd.Driver, resource application.MutuallyExclusiveResource) *application.Provisioner {
 	// Cert manager doesn't need any special handling, ensure it's installed in the specified
 	// remote and in the cert-manager namespace.
-	return application.New(driver, applicationName, resource, helm).InNamespace(applicationName)
+	return application.New(driver, applicationName, resource).InNamespace(applicationName)
 }

--- a/pkg/provisioners/helmapplications/certmanagerissuers/provisioner.go
+++ b/pkg/provisioners/helmapplications/certmanagerissuers/provisioner.go
@@ -17,7 +17,6 @@ limitations under the License.
 package certmanagerissuers
 
 import (
-	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
 	"github.com/eschercloudai/unikorn/pkg/cd"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/application"
 )
@@ -28,6 +27,6 @@ const (
 )
 
 // New returns a new initialized provisioner object.
-func New(driver cd.Driver, resource application.MutuallyExclusiveResource, helm *unikornv1.HelmApplication) *application.Provisioner {
-	return application.New(driver, applicationName, resource, helm)
+func New(driver cd.Driver, resource application.MutuallyExclusiveResource) *application.Provisioner {
+	return application.New(driver, applicationName, resource)
 }

--- a/pkg/provisioners/helmapplications/cilium/provisioner.go
+++ b/pkg/provisioners/helmapplications/cilium/provisioner.go
@@ -29,12 +29,12 @@ const (
 )
 
 // New returns a new initialized provisioner object.
-func New(driver cd.Driver, cluster *unikornv1.KubernetesCluster, helm *unikornv1.HelmApplication) *application.Provisioner {
+func New(driver cd.Driver, cluster *unikornv1.KubernetesCluster) *application.Provisioner {
 	provisioner := &Provisioner{
 		cluster: cluster,
 	}
 
-	return application.New(driver, applicationName, cluster, helm).WithGenerator(provisioner).InNamespace("kube-system")
+	return application.New(driver, applicationName, cluster).WithGenerator(provisioner).InNamespace("kube-system")
 }
 
 type Provisioner struct {

--- a/pkg/provisioners/helmapplications/clusterapi/provisioner.go
+++ b/pkg/provisioners/helmapplications/clusterapi/provisioner.go
@@ -17,7 +17,6 @@ limitations under the License.
 package clusterapi
 
 import (
-	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
 	"github.com/eschercloudai/unikorn/pkg/cd"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/application"
 )
@@ -33,8 +32,8 @@ type Provisioner struct{}
 var _ application.Customizer = &Provisioner{}
 
 // New returns a new initialized provisioner object.
-func New(driver cd.Driver, resource application.MutuallyExclusiveResource, helm *unikornv1.HelmApplication) *application.Provisioner {
-	return application.New(driver, applicationName, resource, helm).WithGenerator(&Provisioner{})
+func New(driver cd.Driver, resource application.MutuallyExclusiveResource) *application.Provisioner {
+	return application.New(driver, applicationName, resource).WithGenerator(&Provisioner{})
 }
 
 // Customize implments the application.Customizer interface.

--- a/pkg/provisioners/helmapplications/clusterautoscaler/provisioner.go
+++ b/pkg/provisioners/helmapplications/clusterautoscaler/provisioner.go
@@ -39,13 +39,13 @@ type Provisioner struct {
 }
 
 // New returns a new initialized provisioner object.
-func New(driver cd.Driver, resource *unikornv1.KubernetesCluster, helm *unikornv1.HelmApplication) *application.Provisioner {
+func New(driver cd.Driver, resource *unikornv1.KubernetesCluster) *application.Provisioner {
 	provisoner := &Provisioner{
 		clusterName:                 clusteropenstack.CAPIClusterName(resource),
 		clusterKubeconfigSecretName: clusteropenstack.KubeconfigSecretName(resource),
 	}
 
-	return application.New(driver, applicationName, resource, helm).WithGenerator(provisoner)
+	return application.New(driver, applicationName, resource).WithGenerator(provisoner)
 }
 
 // Ensure the Provisioner interface is implemented.

--- a/pkg/provisioners/helmapplications/clusterautoscaleropenstack/provisioner.go
+++ b/pkg/provisioners/helmapplications/clusterautoscaleropenstack/provisioner.go
@@ -17,7 +17,6 @@ limitations under the License.
 package clusterautoscaleropenstack
 
 import (
-	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
 	"github.com/eschercloudai/unikorn/pkg/cd"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/application"
 )
@@ -28,6 +27,6 @@ const (
 )
 
 // New returns a new initialized provisioner object.
-func New(driver cd.Driver, resource application.MutuallyExclusiveResource, helm *unikornv1.HelmApplication) *application.Provisioner {
-	return application.New(driver, applicationName, resource, helm)
+func New(driver cd.Driver, resource application.MutuallyExclusiveResource) *application.Provisioner {
+	return application.New(driver, applicationName, resource)
 }

--- a/pkg/provisioners/helmapplications/kubernetesdashboard/provisioner.go
+++ b/pkg/provisioners/helmapplications/kubernetesdashboard/provisioner.go
@@ -23,7 +23,6 @@ import (
 	"net"
 	"strings"
 
-	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
 	"github.com/eschercloudai/unikorn/pkg/cd"
 	"github.com/eschercloudai/unikorn/pkg/constants"
 	"github.com/eschercloudai/unikorn/pkg/provisioners"
@@ -52,12 +51,12 @@ type Provisioner struct {
 var _ application.ValuesGenerator = &Provisioner{}
 
 // New returns a new initialized provisioner object.
-func New(driver cd.Driver, resource application.MutuallyExclusiveResource, helm *unikornv1.HelmApplication, remote provisioners.RemoteCluster) *application.Provisioner {
+func New(driver cd.Driver, resource application.MutuallyExclusiveResource, remote provisioners.RemoteCluster) *application.Provisioner {
 	p := &Provisioner{
 		remote: remote,
 	}
 
-	return application.New(driver, applicationName, resource, helm).WithGenerator(p).InNamespace("kube-system")
+	return application.New(driver, applicationName, resource).WithGenerator(p).InNamespace("kube-system")
 }
 
 func (p *Provisioner) remoteIngressIP(ctx context.Context) (net.IP, error) {

--- a/pkg/provisioners/helmapplications/longhorn/provisioner.go
+++ b/pkg/provisioners/helmapplications/longhorn/provisioner.go
@@ -17,7 +17,6 @@ limitations under the License.
 package longhorn
 
 import (
-	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
 	"github.com/eschercloudai/unikorn/pkg/cd"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/application"
 )
@@ -28,6 +27,6 @@ const (
 )
 
 // New returns a new initialized provisioner object.
-func New(driver cd.Driver, cluster *unikornv1.KubernetesCluster, helm *unikornv1.HelmApplication) *application.Provisioner {
-	return application.New(driver, applicationName, cluster, helm).InNamespace("longhorn-system")
+func New(driver cd.Driver, resource application.MutuallyExclusiveResource) *application.Provisioner {
+	return application.New(driver, applicationName, resource).InNamespace("longhorn-system")
 }

--- a/pkg/provisioners/helmapplications/metricsserver/provisioner.go
+++ b/pkg/provisioners/helmapplications/metricsserver/provisioner.go
@@ -17,7 +17,6 @@ limitations under the License.
 package metricsserver
 
 import (
-	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
 	"github.com/eschercloudai/unikorn/pkg/cd"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/application"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/util"
@@ -34,10 +33,10 @@ type Provisioner struct{}
 var _ application.ValuesGenerator = &Provisioner{}
 
 // New returns a new initialized provisioner object.
-func New(driver cd.Driver, resource application.MutuallyExclusiveResource, helm *unikornv1.HelmApplication) *application.Provisioner {
+func New(driver cd.Driver, resource application.MutuallyExclusiveResource) *application.Provisioner {
 	p := &Provisioner{}
 
-	return application.New(driver, applicationName, resource, helm).WithGenerator(p).InNamespace("kube-system")
+	return application.New(driver, applicationName, resource).WithGenerator(p).InNamespace("kube-system")
 }
 
 // Generate implements the application.Generator interface.

--- a/pkg/provisioners/helmapplications/nginxingress/provisioner.go
+++ b/pkg/provisioners/helmapplications/nginxingress/provisioner.go
@@ -17,7 +17,6 @@ limitations under the License.
 package nginxingress
 
 import (
-	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
 	"github.com/eschercloudai/unikorn/pkg/cd"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/application"
 )
@@ -27,9 +26,7 @@ const (
 	applicationName = "nginx-ingress"
 )
 
-type Provisioner struct{}
-
 // New returns a new initialized provisioner object.
-func New(driver cd.Driver, resource application.MutuallyExclusiveResource, helm *unikornv1.HelmApplication) *application.Provisioner {
-	return application.New(driver, applicationName, resource, helm).InNamespace("nginx-system")
+func New(driver cd.Driver, resource application.MutuallyExclusiveResource) *application.Provisioner {
+	return application.New(driver, applicationName, resource).InNamespace("nginx-system")
 }

--- a/pkg/provisioners/helmapplications/nvidiagpuoperator/provisioner.go
+++ b/pkg/provisioners/helmapplications/nvidiagpuoperator/provisioner.go
@@ -17,7 +17,6 @@ limitations under the License.
 package nvidiagpuoperator
 
 import (
-	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
 	"github.com/eschercloudai/unikorn/pkg/cd"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/application"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/util"
@@ -33,10 +32,10 @@ const (
 )
 
 // New returns a new initialized provisioner object.
-func New(driver cd.Driver, resource application.MutuallyExclusiveResource, helm *unikornv1.HelmApplication) *application.Provisioner {
+func New(driver cd.Driver, resource application.MutuallyExclusiveResource) *application.Provisioner {
 	p := &Provisioner{}
 
-	return application.New(driver, applicationName, resource, helm).WithGenerator(p).InNamespace(defaultNamespace)
+	return application.New(driver, applicationName, resource).WithGenerator(p).InNamespace(defaultNamespace)
 }
 
 type Provisioner struct{}

--- a/pkg/provisioners/helmapplications/openstackcloudprovider/provisioner.go
+++ b/pkg/provisioners/helmapplications/openstackcloudprovider/provisioner.go
@@ -51,12 +51,12 @@ type Provisioner struct {
 }
 
 // New returns a new initialized provisioner object.
-func New(driver cd.Driver, cluster *unikornv1.KubernetesCluster, helm *unikornv1.HelmApplication) *application.Provisioner {
+func New(driver cd.Driver, cluster *unikornv1.KubernetesCluster) *application.Provisioner {
 	provisioner := &Provisioner{
 		cluster: cluster,
 	}
 
-	return application.New(driver, applicationName, cluster, helm).WithGenerator(provisioner).InNamespace("ocp-system")
+	return application.New(driver, applicationName, cluster).WithGenerator(provisioner).InNamespace("ocp-system")
 }
 
 // Ensure the Provisioner interface is implemented.

--- a/pkg/provisioners/helmapplications/openstackplugincindercsi/provisioner.go
+++ b/pkg/provisioners/helmapplications/openstackplugincindercsi/provisioner.go
@@ -49,13 +49,13 @@ type Provisioner struct {
 }
 
 // New returns a new initialized provisioner object.
-func New(driver cd.Driver, cluster *unikornv1.KubernetesCluster, helm *unikornv1.HelmApplication) *application.Provisioner {
+func New(driver cd.Driver, cluster *unikornv1.KubernetesCluster) *application.Provisioner {
 	provisioner := &Provisioner{
 		driver:  driver,
 		cluster: cluster,
 	}
 
-	return application.New(driver, applicationName, cluster, helm).WithGenerator(provisioner).InNamespace("ocp-system")
+	return application.New(driver, applicationName, cluster).WithGenerator(provisioner).InNamespace("ocp-system")
 }
 
 // Ensure the Provisioner interface is implemented.

--- a/pkg/provisioners/helmapplications/prometheus/provisioner.go
+++ b/pkg/provisioners/helmapplications/prometheus/provisioner.go
@@ -17,7 +17,6 @@ limitations under the License.
 package prometheus
 
 import (
-	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
 	"github.com/eschercloudai/unikorn/pkg/cd"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/application"
 )
@@ -28,6 +27,6 @@ const (
 )
 
 // New returns a new initialized provisioner object.
-func New(driver cd.Driver, cluster *unikornv1.KubernetesCluster, helm *unikornv1.HelmApplication) *application.Provisioner {
-	return application.New(driver, applicationName, cluster, helm).InNamespace("prometheus-system")
+func New(driver cd.Driver, resource application.MutuallyExclusiveResource) *application.Provisioner {
+	return application.New(driver, applicationName, resource).InNamespace("prometheus-system")
 }

--- a/pkg/provisioners/helmapplications/vcluster/provisioner.go
+++ b/pkg/provisioners/helmapplications/vcluster/provisioner.go
@@ -19,7 +19,6 @@ package vcluster
 import (
 	"github.com/prometheus/client_golang/prometheus"
 
-	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
 	"github.com/eschercloudai/unikorn/pkg/cd"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/application"
 
@@ -54,6 +53,6 @@ func init() {
 }
 
 // New returns a new initialized provisioner object.
-func New(driver cd.Driver, resource application.MutuallyExclusiveResource, helm *unikornv1.HelmApplication) *application.Provisioner {
-	return application.New(driver, applicationName, resource, helm)
+func New(driver cd.Driver, resource application.MutuallyExclusiveResource) *application.Provisioner {
+	return application.New(driver, applicationName, resource)
 }

--- a/pkg/provisioners/util/unbundler.go
+++ b/pkg/provisioners/util/unbundler.go
@@ -31,9 +31,10 @@ var (
 	ErrApplicationMissing = errors.New("bundle missing expected application")
 )
 
-// BundledType is a type, typically a custom resource, that has an attached
+// ApplicationBundleGetter is a type, typically a custom resource, that has an attached
 // application bundle.
-type BundledType interface {
+type ApplicationBundleGetter interface {
+	ApplicationBundleKind() unikornv1.ApplicationBundleResourceKind
 	ApplicationBundleName() string
 }
 
@@ -65,10 +66,10 @@ type Unbundler struct {
 	items []unbundleItem
 }
 
-func NewUnbundler(o BundledType, kind unikornv1.ApplicationBundleResourceKind) *Unbundler {
+func NewUnbundler(o ApplicationBundleGetter) *Unbundler {
 	return &Unbundler{
 		name: o.ApplicationBundleName(),
-		kind: kind,
+		kind: o.ApplicationBundleKind(),
 	}
 }
 


### PR DESCRIPTION
I noted in the prior commit that handling of applications and bundles is quite messy, and it's been brewing for quite some time, but all applications have a name, and they should use that to lookup the application from the avaialble bundle, rather than having the application passed down to it.  Turns out it was relatively easy, and does wonders for code clarity.  Quite surprisingly the stars mostly aligned, and it was just the cluster-openstack that generated a different Application name to its HelmApplication, but easily remedied.