### PR TITLE
Finsih Cluster Manager Provisioner Cleanup

### DIFF
--- a/pkg/provisioners/helmapplications/clusteropenstack/provisioner.go
+++ b/pkg/provisioners/helmapplications/clusteropenstack/provisioner.go
@@ -26,7 +26,6 @@ import (
 	"github.com/eschercloudai/unikorn/pkg/constants"
 	"github.com/eschercloudai/unikorn/pkg/provisioners"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/application"
-	"github.com/eschercloudai/unikorn/pkg/util"
 )
 
 const (
@@ -61,16 +60,7 @@ type Provisioner struct {
 }
 
 // New returns a new initialized provisioner object.
-func New(ctx context.Context, driver cd.Driver, cluster *unikornv1.KubernetesCluster) (*Provisioner, error) {
-	// Add the SNAT address of the control plane's default route.
-	// Sadly, we are the only thing guaranteed to live behind the same
-	// router, the CLI tools and UI are or can be used anywhere, so
-	// we'll take on this hack.
-	controlPlanePrefix, err := util.GetNATPrefix(ctx)
-	if err != nil {
-		return nil, err
-	}
-
+func New(ctx context.Context, driver cd.Driver, cluster *unikornv1.KubernetesCluster, controlPlanePrefix string) *Provisioner {
 	provisioner := &Provisioner{
 		ProvisionerMeta: provisioners.ProvisionerMeta{
 			Name: cluster.Name,
@@ -80,7 +70,7 @@ func New(ctx context.Context, driver cd.Driver, cluster *unikornv1.KubernetesClu
 		controlPlanePrefix: controlPlanePrefix,
 	}
 
-	return provisioner, nil
+	return provisioner
 }
 
 // Ensure the Provisioner interface is implemented.

--- a/pkg/provisioners/util.go
+++ b/pkg/provisioners/util.go
@@ -23,6 +23,7 @@ import (
 
 // VClusterRemoteLabelsFromControlPlane extracts a unique set of labels from the
 // control plane for a remote vcluster.
+// TODO: this should be an interface on the resource type.
 func VClusterRemoteLabelsFromControlPlane(controlPlane *unikornv1alpha1.ControlPlane) []string {
 	return []string{
 		controlPlane.Name,


### PR DESCRIPTION
Removes some more smell code from the core cluster provisioner and attain some kind of parity across all provisioners.