### PR TITLE
Post Provision Application Hooks

### DIFF
--- a/pkg/cd/argocd/driver.go
+++ b/pkg/cd/argocd/driver.go
@@ -101,6 +101,11 @@ func applicationLabels(id *cd.ResourceIdentifier) labels.Set {
 	return labels
 }
 
+// Kind returns the driver kind.
+func (d *Driver) Kind() cd.DriverKind {
+	return cd.DriverKindArgoCD
+}
+
 // Client gets the Kubernetes client.
 func (d *Driver) Client() client.Client {
 	return d.kubernetesClient

--- a/pkg/cd/argocd/driver_test.go
+++ b/pkg/cd/argocd/driver_test.go
@@ -103,8 +103,8 @@ func TestApplicationCreateHelm(t *testing.T) {
 	assert.Nil(t, application.Spec.Source.Helm)
 	assert.Equal(t, "in-cluster", application.Spec.Destination.Name)
 	assert.Equal(t, "", application.Spec.Destination.Namespace)
-	assert.Equal(t, true, application.Spec.SyncPolicy.Automated.SelfHeal)
-	assert.Equal(t, true, application.Spec.SyncPolicy.Automated.Prune)
+	assert.True(t, application.Spec.SyncPolicy.Automated.SelfHeal)
+	assert.True(t, application.Spec.SyncPolicy.Automated.Prune)
 	assert.Nil(t, application.Spec.SyncPolicy.SyncOptions)
 }
 
@@ -183,8 +183,8 @@ func TestApplicationCreateHelmExtended(t *testing.T) {
 	assert.Equal(t, fmt.Sprintf("%s: %s\n", valuesKey, valuesValue), application.Spec.Source.Helm.Values)
 	assert.Equal(t, remoteDestination, application.Spec.Destination.Name)
 	assert.Equal(t, "", application.Spec.Destination.Namespace)
-	assert.Equal(t, true, application.Spec.SyncPolicy.Automated.SelfHeal)
-	assert.Equal(t, true, application.Spec.SyncPolicy.Automated.Prune)
+	assert.True(t, application.Spec.SyncPolicy.Automated.SelfHeal)
+	assert.True(t, application.Spec.SyncPolicy.Automated.Prune)
 	assert.Equal(t, 2, len(application.Spec.SyncPolicy.SyncOptions))
 	assert.Equal(t, argoprojv1.CreateNamespace, application.Spec.SyncPolicy.SyncOptions[0])
 	assert.Equal(t, argoprojv1.ServerSideApply, application.Spec.SyncPolicy.SyncOptions[1])
@@ -224,8 +224,8 @@ func TestApplicationCreateGit(t *testing.T) {
 	assert.Nil(t, application.Spec.Source.Helm)
 	assert.Equal(t, "in-cluster", application.Spec.Destination.Name)
 	assert.Equal(t, "", application.Spec.Destination.Namespace)
-	assert.Equal(t, true, application.Spec.SyncPolicy.Automated.SelfHeal)
-	assert.Equal(t, true, application.Spec.SyncPolicy.Automated.Prune)
+	assert.True(t, application.Spec.SyncPolicy.Automated.SelfHeal)
+	assert.True(t, application.Spec.SyncPolicy.Automated.Prune)
 	assert.Nil(t, application.Spec.SyncPolicy.SyncOptions)
 	assert.Nil(t, application.Spec.IgnoreDifferences)
 }
@@ -268,8 +268,8 @@ func TestApplicationUpdateAndDelete(t *testing.T) {
 	assert.Nil(t, application.Spec.Source.Helm)
 	assert.Equal(t, "in-cluster", application.Spec.Destination.Name)
 	assert.Equal(t, "", application.Spec.Destination.Namespace)
-	assert.Equal(t, true, application.Spec.SyncPolicy.Automated.SelfHeal)
-	assert.Equal(t, true, application.Spec.SyncPolicy.Automated.Prune)
+	assert.True(t, application.Spec.SyncPolicy.Automated.SelfHeal)
+	assert.True(t, application.Spec.SyncPolicy.Automated.Prune)
 	assert.Nil(t, application.Spec.SyncPolicy.SyncOptions)
 
 	assert.ErrorIs(t, tc.driver.DeleteHelmApplication(context.TODO(), id, false), provisioners.ErrYield)

--- a/pkg/cd/interfaces.go
+++ b/pkg/cd/interfaces.go
@@ -28,6 +28,13 @@ import (
 // or Flux, this is a low level driver interface that configures things
 // like remote clusters and Helm applications.
 type Driver interface {
+	// Kind allows provisioners to make decisions based on the driver
+	// in use e.g. if the CD is broken in some way and needs manual
+	// intervention.  Use of this is discouraged, and pull requests will
+	// be rejected if there's no evidence of an upstream fix to remove
+	// your hack.
+	Kind() DriverKind
+
 	// Client gives you access to the Kubernetes client for when your CD driver
 	// is incapable of working as desired and you need to take manual action.
 	// Think long and hard about whether you need this, it's a hack quite frankly.

--- a/pkg/cd/mock/interfaces.go
+++ b/pkg/cd/mock/interfaces.go
@@ -109,3 +109,17 @@ func (mr *MockDriverMockRecorder) DeleteHelmApplication(ctx, id, backgroundDelet
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteHelmApplication", reflect.TypeOf((*MockDriver)(nil).DeleteHelmApplication), ctx, id, backgroundDelete)
 }
+
+// Kind mocks base method.
+func (m *MockDriver) Kind() cd.DriverKind {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Kind")
+	ret0, _ := ret[0].(cd.DriverKind)
+	return ret0
+}
+
+// Kind indicates an expected call of Kind.
+func (mr *MockDriverMockRecorder) Kind() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Kind", reflect.TypeOf((*MockDriver)(nil).Kind))
+}

--- a/pkg/cd/types.go
+++ b/pkg/cd/types.go
@@ -20,6 +20,14 @@ import (
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
 
+// DriverKind allows the provisioners to make CD specific hacks for when
+// the underlying provider is broken in some way.
+type DriverKind string
+
+const (
+	DriverKindArgoCD DriverKind = "argocd"
+)
+
 // ResourceIdentifierLabel is a single key/value pair that can
 // be used to specify context in a resource identifier.
 type ResourceIdentifierLabel struct {

--- a/pkg/provisioners/helmapplications/clusteropenstack/hack.go
+++ b/pkg/provisioners/helmapplications/clusteropenstack/hack.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/eschercloudai/unikorn/pkg/cd"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/helmapplications/vcluster"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -207,6 +208,10 @@ func deleteForeignResources(ctx context.Context, c client.Client, objects []unst
 //
 //nolint:cyclop
 func (p *Provisioner) deleteOrphanedMachineDeployments(ctx context.Context) error {
+	if p.driver.Kind() != cd.DriverKindArgoCD {
+		return nil
+	}
+
 	vc := vcluster.NewControllerRuntimeClient(p.driver.Client())
 
 	vclusterClient, err := vc.Client(ctx, p.cluster.Namespace, false)


### PR DESCRIPTION
Imbue the application provisioner with the power to invoke a post-provision hook, which removes the last "special" helm application that had to define its own provisioner type, rather than piggy-back on the application.  This simplifies things, deletes a bunch of crap, and provides a generic framework.  As the hook itself is an Argo specific hack, provide a way so the hack knows what it's using and whether or not action needs to be taken.