### PR TITLE
Driver refactor

### DIFF
--- a/charts/unikorn/templates/unikorn-cluster-manager.yaml
+++ b/charts/unikorn/templates/unikorn-cluster-manager.yaml
@@ -55,7 +55,7 @@ rules:
   - watch
   - patch
   - delete
-# V-cluster integration (access to kubeconfig).
+# ArgoCD integration (access to API secret).
 - apiGroups:
   - ""
   resources:

--- a/charts/unikorn/templates/unikorn-control-plane-manager.yaml
+++ b/charts/unikorn/templates/unikorn-control-plane-manager.yaml
@@ -75,7 +75,7 @@ rules:
   - watch
   - patch
   - delete
-# V-cluster integration (access to kubeconfig).
+# ArgoCD integration (access to API secret).
 - apiGroups:
   - ""
   resources:

--- a/charts/unikorn/templates/unikorn-project-manager.yaml
+++ b/charts/unikorn/templates/unikorn-project-manager.yaml
@@ -54,6 +54,14 @@ rules:
   - get
   - watch
   - delete
+# ArgoCD integration (access to API secret).
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/pkg/cd/argocd/driver.go
+++ b/pkg/cd/argocd/driver.go
@@ -61,12 +61,10 @@ var _ cd.Driver = &Driver{}
 
 // NewDriver creates a new ArgoCD driver.
 func NewDriver(kubernetesClient client.Client, argoCDClient Client) *Driver {
-	driver := &Driver{
+	return &Driver{
 		argoCDClient:     argoCDClient,
 		kubernetesClient: kubernetesClient,
 	}
-
-	return driver
 }
 
 // clusterName generates a cluster name from a cluster identifier.

--- a/pkg/cd/flags.go
+++ b/pkg/cd/flags.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2022-2023 EscherCloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cd
+
+import (
+	"slices"
+
+	"github.com/spf13/pflag"
+
+	"github.com/eschercloudai/unikorn/pkg/errors"
+)
+
+// DriverKindFlag wraps up the driver kind in a flag that can be used on the CLI.
+type DriverKindFlag struct {
+	Kind DriverKind
+}
+
+var _ pflag.Value = &DriverKindFlag{}
+
+// String implemenets the pflag.Value interface.
+func (s *DriverKindFlag) String() string {
+	return string(s.Kind)
+}
+
+// Set implemenets the pflag.Value interface.
+func (s *DriverKindFlag) Set(in string) error {
+	valid := []DriverKind{
+		DriverKindArgoCD,
+	}
+
+	value := DriverKind(in)
+
+	if !slices.Contains(valid, value) {
+		return errors.ErrParseFlag
+	}
+
+	s.Kind = value
+
+	return nil
+}
+
+// Type implemenets the pflag.Value interface.
+func (s *DriverKindFlag) Type() string {
+	return "string"
+}

--- a/pkg/cd/mock/interfaces.go
+++ b/pkg/cd/mock/interfaces.go
@@ -123,3 +123,68 @@ func (mr *MockDriverMockRecorder) Kind() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Kind", reflect.TypeOf((*MockDriver)(nil).Kind))
 }
+
+// MockDriverRunnable is a mock of DriverRunnable interface.
+type MockDriverRunnable struct {
+	ctrl     *gomock.Controller
+	recorder *MockDriverRunnableMockRecorder
+}
+
+// MockDriverRunnableMockRecorder is the mock recorder for MockDriverRunnable.
+type MockDriverRunnableMockRecorder struct {
+	mock *MockDriverRunnable
+}
+
+// NewMockDriverRunnable creates a new mock instance.
+func NewMockDriverRunnable(ctrl *gomock.Controller) *MockDriverRunnable {
+	mock := &MockDriverRunnable{ctrl: ctrl}
+	mock.recorder = &MockDriverRunnableMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockDriverRunnable) EXPECT() *MockDriverRunnableMockRecorder {
+	return m.recorder
+}
+
+// Driver mocks base method.
+func (m *MockDriverRunnable) Driver() cd.Driver {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Driver")
+	ret0, _ := ret[0].(cd.Driver)
+	return ret0
+}
+
+// Driver indicates an expected call of Driver.
+func (mr *MockDriverRunnableMockRecorder) Driver() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Driver", reflect.TypeOf((*MockDriverRunnable)(nil).Driver))
+}
+
+// NeedLeaderElection mocks base method.
+func (m *MockDriverRunnable) NeedLeaderElection() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NeedLeaderElection")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// NeedLeaderElection indicates an expected call of NeedLeaderElection.
+func (mr *MockDriverRunnableMockRecorder) NeedLeaderElection() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NeedLeaderElection", reflect.TypeOf((*MockDriverRunnable)(nil).NeedLeaderElection))
+}
+
+// Start mocks base method.
+func (m *MockDriverRunnable) Start(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Start", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Start indicates an expected call of Start.
+func (mr *MockDriverRunnableMockRecorder) Start(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockDriverRunnable)(nil).Start), arg0)
+}

--- a/pkg/cmd/util/flags/flags.go
+++ b/pkg/cmd/util/flags/flags.go
@@ -18,7 +18,6 @@ package flags
 
 import (
 	"encoding/csv"
-	"errors"
 	"fmt"
 	"net"
 	"regexp"
@@ -27,12 +26,9 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	"k8s.io/apimachinery/pkg/api/resource"
-)
+	"github.com/eschercloudai/unikorn/pkg/errors"
 
-var (
-	// ErrParseFlag is raised when flag parsing fails.
-	ErrParseFlag = errors.New("flag was unable to be parsed")
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 // SemverFlag provides parsing and type checking of semantic versions.
@@ -58,7 +54,7 @@ func (s *SemverFlag) Set(in string) error {
 	}
 
 	if !ok {
-		return fmt.Errorf("%w: flag must match v1.2.3", ErrParseFlag)
+		return fmt.Errorf("%w: flag must match v1.2.3", errors.ErrParseFlag)
 	}
 
 	s.Semver = in

--- a/pkg/errors/errors.go
+++ b/pkg/errors/errors.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2022-2023 EscherCloud.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package errors
+
+import (
+	"errors"
+)
+
+var (
+	// ErrParseFlag is raised when flag parsing fails.
+	ErrParseFlag = errors.New("flag was unable to be parsed")
+
+	// ErrCDDriver is raised when a CD driver is not handled.
+	ErrCDDriver = errors.New("unhandled CD driver")
+)

--- a/pkg/managers/cluster/manager.go
+++ b/pkg/managers/cluster/manager.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
+	"github.com/eschercloudai/unikorn/pkg/cd"
 	"github.com/eschercloudai/unikorn/pkg/managers/common"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/managers/cluster"
 
@@ -97,8 +98,8 @@ type Factory struct{}
 var _ common.ControllerFactory = &Factory{}
 
 // Reconciler returns a new reconciler instance.
-func (*Factory) Reconciler(manager manager.Manager) reconcile.Reconciler {
-	return common.NewReconciler(manager.GetClient(), cluster.New)
+func (*Factory) Reconciler(manager manager.Manager, driverRunnable cd.DriverRunnable) reconcile.Reconciler {
+	return common.NewReconciler(manager.GetClient(), driverRunnable, cluster.New)
 }
 
 // RegisterWatches adds any watches that would trigger a reconcile.

--- a/pkg/managers/common/reconcile_test.go
+++ b/pkg/managers/common/reconcile_test.go
@@ -29,10 +29,12 @@ import (
 	"go.uber.org/mock/gomock"
 
 	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
+	"github.com/eschercloudai/unikorn/pkg/cd"
+	mockcd "github.com/eschercloudai/unikorn/pkg/cd/mock"
 	"github.com/eschercloudai/unikorn/pkg/constants"
 	"github.com/eschercloudai/unikorn/pkg/managers/common"
 	"github.com/eschercloudai/unikorn/pkg/provisioners"
-	"github.com/eschercloudai/unikorn/pkg/provisioners/mock"
+	mockprovisioners "github.com/eschercloudai/unikorn/pkg/provisioners/mock"
 	clientutil "github.com/eschercloudai/unikorn/pkg/util/client"
 
 	corev1 "k8s.io/api/core/v1"
@@ -132,10 +134,13 @@ func TestReconcileDeleted(t *testing.T) {
 	tc := mustNewTestContext(t)
 	ctx := context.Background()
 
-	p := mock.NewMockManagerProvisioner(c)
+	p := mockprovisioners.NewMockManagerProvisioner(c)
 	p.EXPECT().Object().Return(&unikornv1.Project{})
 
-	reconciler := common.NewReconciler(tc.client, func(c client.Client) provisioners.ManagerProvisioner { return p })
+	d := mockcd.NewMockDriverRunnable(c)
+	d.EXPECT().Driver().Return(nil)
+
+	reconciler := common.NewReconciler(tc.client, d, func(_ client.Client, _ cd.Driver) provisioners.ManagerProvisioner { return p })
 
 	_, err := reconciler.Reconcile(ctx, newRequest(testNamespace, testName))
 	assert.NoError(t, err)
@@ -158,11 +163,14 @@ func TestReconcileCreate(t *testing.T) {
 	tc := mustNewTestContext(t, request)
 	ctx := context.Background()
 
-	p := mock.NewMockManagerProvisioner(c)
+	d := mockcd.NewMockDriverRunnable(c)
+	d.EXPECT().Driver().Return(nil)
+
+	p := mockprovisioners.NewMockManagerProvisioner(c)
 	p.EXPECT().Object().Return(&unikornv1.Project{})
 	p.EXPECT().Provision(ctx).Return(nil)
 
-	reconciler := common.NewReconciler(tc.client, func(c client.Client) provisioners.ManagerProvisioner { return p })
+	reconciler := common.NewReconciler(tc.client, d, func(_ client.Client, _ cd.Driver) provisioners.ManagerProvisioner { return p })
 
 	_, err := reconciler.Reconcile(ctx, newRequest(testNamespace, testName))
 	assert.NoError(t, err)
@@ -193,11 +201,14 @@ func TestReconcileCreateYield(t *testing.T) {
 	tc := mustNewTestContext(t, request)
 	ctx := context.Background()
 
-	p := mock.NewMockManagerProvisioner(c)
+	d := mockcd.NewMockDriverRunnable(c)
+	d.EXPECT().Driver().Return(nil)
+
+	p := mockprovisioners.NewMockManagerProvisioner(c)
 	p.EXPECT().Object().Return(&unikornv1.Project{})
 	p.EXPECT().Provision(ctx).Return(provisioners.ErrYield)
 
-	reconciler := common.NewReconciler(tc.client, func(c client.Client) provisioners.ManagerProvisioner { return p })
+	reconciler := common.NewReconciler(tc.client, d, func(_ client.Client, _ cd.Driver) provisioners.ManagerProvisioner { return p })
 
 	_, err := reconciler.Reconcile(ctx, newRequest(testNamespace, testName))
 	assert.NoError(t, err)
@@ -230,11 +241,14 @@ func TestReconcileCreateCancelled(t *testing.T) {
 
 	cancel()
 
-	p := mock.NewMockManagerProvisioner(c)
+	d := mockcd.NewMockDriverRunnable(c)
+	d.EXPECT().Driver().Return(nil)
+
+	p := mockprovisioners.NewMockManagerProvisioner(c)
 	p.EXPECT().Object().Return(&unikornv1.Project{})
 	p.EXPECT().Provision(ctx).Return(ctx.Err())
 
-	reconciler := common.NewReconciler(tc.client, func(c client.Client) provisioners.ManagerProvisioner { return p })
+	reconciler := common.NewReconciler(tc.client, d, func(_ client.Client, _ cd.Driver) provisioners.ManagerProvisioner { return p })
 
 	_, err := reconciler.Reconcile(ctx, newRequest(testNamespace, testName))
 	assert.NoError(t, err)
@@ -265,11 +279,14 @@ func TestReconcileCreateError(t *testing.T) {
 	tc := mustNewTestContext(t, request)
 	ctx := context.Background()
 
-	p := mock.NewMockManagerProvisioner(c)
+	d := mockcd.NewMockDriverRunnable(c)
+	d.EXPECT().Driver().Return(nil)
+
+	p := mockprovisioners.NewMockManagerProvisioner(c)
 	p.EXPECT().Object().Return(&unikornv1.Project{})
 	p.EXPECT().Provision(ctx).Return(errUnhandled)
 
-	reconciler := common.NewReconciler(tc.client, func(c client.Client) provisioners.ManagerProvisioner { return p })
+	reconciler := common.NewReconciler(tc.client, d, func(_ client.Client, _ cd.Driver) provisioners.ManagerProvisioner { return p })
 
 	_, err := reconciler.Reconcile(ctx, newRequest(testNamespace, testName))
 	assert.NoError(t, err)
@@ -306,11 +323,14 @@ func TestReconcileDelete(t *testing.T) {
 	tc := mustNewTestContext(t, request)
 	ctx := context.Background()
 
-	p := mock.NewMockManagerProvisioner(c)
+	d := mockcd.NewMockDriverRunnable(c)
+	d.EXPECT().Driver().Return(nil)
+
+	p := mockprovisioners.NewMockManagerProvisioner(c)
 	p.EXPECT().Object().Return(&unikornv1.Project{})
 	p.EXPECT().Deprovision(ctx).Return(nil)
 
-	reconciler := common.NewReconciler(tc.client, func(c client.Client) provisioners.ManagerProvisioner { return p })
+	reconciler := common.NewReconciler(tc.client, d, func(_ client.Client, _ cd.Driver) provisioners.ManagerProvisioner { return p })
 
 	_, err := reconciler.Reconcile(ctx, newRequest(testNamespace, testName))
 	assert.NoError(t, err)
@@ -348,11 +368,14 @@ func TestReconcileDeleteYield(t *testing.T) {
 	tc := mustNewTestContext(t, request)
 	ctx := context.Background()
 
-	p := mock.NewMockManagerProvisioner(c)
+	d := mockcd.NewMockDriverRunnable(c)
+	d.EXPECT().Driver().Return(nil)
+
+	p := mockprovisioners.NewMockManagerProvisioner(c)
 	p.EXPECT().Object().Return(&unikornv1.Project{})
 	p.EXPECT().Deprovision(ctx).Return(provisioners.ErrYield)
 
-	reconciler := common.NewReconciler(tc.client, func(c client.Client) provisioners.ManagerProvisioner { return p })
+	reconciler := common.NewReconciler(tc.client, d, func(_ client.Client, _ cd.Driver) provisioners.ManagerProvisioner { return p })
 
 	_, err := reconciler.Reconcile(ctx, newRequest(testNamespace, testName))
 	assert.NoError(t, err)
@@ -391,11 +414,14 @@ func TestReconcileDeleteCancelled(t *testing.T) {
 
 	cancel()
 
-	p := mock.NewMockManagerProvisioner(c)
+	d := mockcd.NewMockDriverRunnable(c)
+	d.EXPECT().Driver().Return(nil)
+
+	p := mockprovisioners.NewMockManagerProvisioner(c)
 	p.EXPECT().Object().Return(&unikornv1.Project{})
 	p.EXPECT().Deprovision(ctx).Return(ctx.Err())
 
-	reconciler := common.NewReconciler(tc.client, func(c client.Client) provisioners.ManagerProvisioner { return p })
+	reconciler := common.NewReconciler(tc.client, d, func(_ client.Client, _ cd.Driver) provisioners.ManagerProvisioner { return p })
 
 	_, err := reconciler.Reconcile(ctx, newRequest(testNamespace, testName))
 	assert.NoError(t, err)
@@ -432,11 +458,14 @@ func TestReconcileDeleteError(t *testing.T) {
 	tc := mustNewTestContext(t, request)
 	ctx := context.Background()
 
-	p := mock.NewMockManagerProvisioner(c)
+	d := mockcd.NewMockDriverRunnable(c)
+	d.EXPECT().Driver().Return(nil)
+
+	p := mockprovisioners.NewMockManagerProvisioner(c)
 	p.EXPECT().Object().Return(&unikornv1.Project{})
 	p.EXPECT().Deprovision(ctx).Return(errUnhandled)
 
-	reconciler := common.NewReconciler(tc.client, func(c client.Client) provisioners.ManagerProvisioner { return p })
+	reconciler := common.NewReconciler(tc.client, d, func(_ client.Client, _ cd.Driver) provisioners.ManagerProvisioner { return p })
 
 	_, err := reconciler.Reconcile(ctx, newRequest(testNamespace, testName))
 	assert.NoError(t, err)

--- a/pkg/managers/controlplane/manager.go
+++ b/pkg/managers/controlplane/manager.go
@@ -18,6 +18,7 @@ package controlplane
 
 import (
 	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
+	"github.com/eschercloudai/unikorn/pkg/cd"
 	"github.com/eschercloudai/unikorn/pkg/managers/common"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/managers/controlplane"
 
@@ -36,8 +37,8 @@ type Factory struct{}
 var _ common.ControllerFactory = &Factory{}
 
 // Reconciler returns a new reconciler instance.
-func (*Factory) Reconciler(manager manager.Manager) reconcile.Reconciler {
-	return common.NewReconciler(manager.GetClient(), controlplane.New)
+func (*Factory) Reconciler(manager manager.Manager, driverRunnable cd.DriverRunnable) reconcile.Reconciler {
+	return common.NewReconciler(manager.GetClient(), driverRunnable, controlplane.New)
 }
 
 // RegisterWatches adds any watches that would trigger a reconcile.

--- a/pkg/managers/options/options.go
+++ b/pkg/managers/options/options.go
@@ -18,6 +18,8 @@ package options
 
 import (
 	"github.com/spf13/pflag"
+
+	"github.com/eschercloudai/unikorn/pkg/cd"
 )
 
 // Options defines common controller options.
@@ -26,8 +28,15 @@ type Options struct {
 	// concurrently.  Be warned, this will inrcrease memory utilization
 	// and may need to update the Helm limits.
 	MaxConcurrentReconciles int
+
+	// CDDriver defines the continuous-delivery backend driver to use
+	// to manage applications.
+	CDDriver cd.DriverKindFlag
 }
 
 func (o *Options) AddFlags(flags *pflag.FlagSet) {
+	o.CDDriver.Kind = cd.DriverKindArgoCD
+
 	flags.IntVar(&o.MaxConcurrentReconciles, "--max-concurrency", 16, "Maximum number of requests to process at the same time")
+	flags.Var(&o.CDDriver, "--cd-driver", "CD backend driver to use from [argocd]")
 }

--- a/pkg/managers/project/manager.go
+++ b/pkg/managers/project/manager.go
@@ -18,6 +18,7 @@ package project
 
 import (
 	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
+	"github.com/eschercloudai/unikorn/pkg/cd"
 	"github.com/eschercloudai/unikorn/pkg/managers/common"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/managers/project"
 
@@ -36,8 +37,8 @@ type Factory struct{}
 var _ common.ControllerFactory = &Factory{}
 
 // Reconciler returns a new reconciler instance.
-func (*Factory) Reconciler(manager manager.Manager) reconcile.Reconciler {
-	return common.NewReconciler(manager.GetClient(), project.New)
+func (*Factory) Reconciler(manager manager.Manager, driverRunnable cd.DriverRunnable) reconcile.Reconciler {
+	return common.NewReconciler(manager.GetClient(), driverRunnable, project.New)
 }
 
 // RegisterWatches adds any watches that would trigger a reconcile.

--- a/pkg/provisioners/managers/project/provisioner.go
+++ b/pkg/provisioners/managers/project/provisioner.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 
 	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
+	"github.com/eschercloudai/unikorn/pkg/cd"
 	"github.com/eschercloudai/unikorn/pkg/provisioners"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/resource"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/util"
@@ -47,7 +48,7 @@ type Provisioner struct {
 }
 
 // New returns a new initialized provisioner object.
-func New(client client.Client) provisioners.ManagerProvisioner {
+func New(client client.Client, _ cd.Driver) provisioners.ManagerProvisioner {
 	return &Provisioner{
 		client: client,
 	}


### PR DESCRIPTION
This was hacked in and done every time we reconciled, but what we should be doing is creating one driver and reusing it.  The other benefits are that we can also do the driver selection bit and create a flag for it. Hard part was integrating it with controller-runtime, but there is a way to have it start after the client is up and running, and before leadership election kicks in and unleashes the reconciler that will require the driver to be available.