### PR TITLE
Upgrade to CAPO 0.8.0

### DIFF
--- a/charts/unikorn/crds/unikorn.eschercloud.ai_kubernetesclusters.yaml
+++ b/charts/unikorn/crds/unikorn.eschercloud.ai_kubernetesclusters.yaml
@@ -400,7 +400,6 @@ spec:
                       reply on this behaviour.
                     type: string
                 required:
-                - caCert
                 - cloud
                 - cloudConfig
                 - externalNetworkId

--- a/charts/unikorn/templates/applicationbundles.yaml
+++ b/charts/unikorn/templates/applicationbundles.yaml
@@ -17,7 +17,7 @@ spec:
   - name: cluster-api
     reference:
       kind: HelmApplication
-      name: cluster-api-0.1.8-1
+      name: cluster-api-0.1.9-1
 ---
 apiVersion: unikorn.eschercloud.ai/v1alpha1
 kind: ApplicationBundle
@@ -28,18 +28,18 @@ spec:
   version: 1.2.0
   preview: true
   applications:
-    - name: vcluster
-      reference:
-        kind: HelmApplication
-        name: vcluster-0.15.7-1
-    - name: cert-manager
-      reference:
-        kind: HelmApplication
-        name: cert-manager-1.12.4-1
-    - name: cluster-api
-      reference:
-        kind: HelmApplication
-        name: cluster-api-0.1.8-1
+  - name: vcluster
+    reference:
+      kind: HelmApplication
+      name: vcluster-0.15.7-1
+  - name: cert-manager
+    reference:
+      kind: HelmApplication
+      name: cert-manager-1.12.4-1
+  - name: cluster-api
+    reference:
+      kind: HelmApplication
+      name: cluster-api-0.1.9-1
 ---
 apiVersion: unikorn.eschercloud.ai/v1alpha1
 kind: ApplicationBundle
@@ -52,7 +52,7 @@ spec:
   - name: cluster-openstack
     reference:
       kind: HelmApplication
-      name: cluster-openstack-0.3.25-1
+      name: cluster-openstack-0.3.26-1
   - name: cilium
     reference:
       kind: HelmApplication
@@ -126,7 +126,7 @@ spec:
   - name: cluster-openstack
     reference:
       kind: HelmApplication
-      name: cluster-openstack-0.3.25-1
+      name: cluster-openstack-0.3.26-1
   - name: cilium
     reference:
       kind: HelmApplication

--- a/charts/unikorn/templates/applications.yaml
+++ b/charts/unikorn/templates/applications.yaml
@@ -65,15 +65,13 @@ spec:
 apiVersion: unikorn.eschercloud.ai/v1alpha1
 kind: HelmApplication
 metadata:
-  name: cluster-api-0.1.8-1
+  name: cluster-api-0.1.9-1
 spec:
+  repo: https://github.com/eschercloudai/helm-cluster-api
   repo: https://eschercloudai.github.io/helm-cluster-api
   chart: cluster-api
-  version: v0.1.8
+  version: v0.1.9
   interface: 1.0.0
-  parameters:
-  - name: cluster-api-provider-openstack.image
-    value: spjmurray/capi-openstack-controller-amd64:v0.7.3-simon7
 ---
 apiVersion: unikorn.eschercloud.ai/v1alpha1
 kind: HelmApplication
@@ -110,11 +108,12 @@ spec:
 apiVersion: unikorn.eschercloud.ai/v1alpha1
 kind: HelmApplication
 metadata:
-  name: cluster-openstack-0.3.25-1
+  name: cluster-openstack-0.3.26-1
 spec:
+  repo: https://github.com/eschercloudai/helm-cluster-api
   repo: https://eschercloudai.github.io/helm-cluster-api
   chart: cluster-api-cluster-openstack
-  version: v0.3.25
+  version: v0.3.26
   createNamespace: true
   interface: 1.0.0
 ---

--- a/pkg/apis/unikorn/v1alpha1/types.go
+++ b/pkg/apis/unikorn/v1alpha1/types.go
@@ -452,7 +452,7 @@ type KubernetesClusterSpec struct {
 
 type KubernetesClusterOpenstackSpec struct {
 	// CACert is the CA used to trust the Openstack endpoint.
-	CACert *[]byte `json:"caCert"`
+	CACert *[]byte `json:"caCert,omitempty"`
 	// CloudConfig is a base64 encoded minimal clouds.yaml file for
 	// use by the ControlPlane to provision the IaaS bits.
 	CloudConfig *[]byte `json:"cloudConfig"`

--- a/pkg/cmd/create/create_cluster.go
+++ b/pkg/cmd/create/create_cluster.go
@@ -32,7 +32,6 @@ import (
 	"github.com/eschercloudai/unikorn/pkg/cmd/util/completion"
 	"github.com/eschercloudai/unikorn/pkg/cmd/util/flags"
 	"github.com/eschercloudai/unikorn/pkg/constants"
-	uutil "github.com/eschercloudai/unikorn/pkg/util"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -244,14 +243,6 @@ func (o *createClusterOptions) completeOpenstackConfig() error {
 	}
 
 	o.clouds = filteredCloudsYaml
-
-	// Work out the correct CA to use.
-	ca, err := uutil.GetURLCACertificate(cloud.AuthInfo.AuthURL)
-	if err != nil {
-		return err
-	}
-
-	o.caCert = ca
 
 	return nil
 }

--- a/pkg/provisioners/helmapplications/clusteropenstack/provisioner.go
+++ b/pkg/provisioners/helmapplications/clusteropenstack/provisioner.go
@@ -199,10 +199,13 @@ func (p *Provisioner) Values(version *string) (interface{}, error) {
 	openstackValues := map[string]interface{}{
 		"cloud":                *p.cluster.Spec.Openstack.Cloud,
 		"cloudsYAML":           base64.StdEncoding.EncodeToString(*p.cluster.Spec.Openstack.CloudConfig),
-		"ca":                   base64.StdEncoding.EncodeToString(*p.cluster.Spec.Openstack.CACert),
 		"computeFailureDomain": *p.cluster.Spec.Openstack.FailureDomain,
 		"volumeFailureDomain":  *volumeFailureDomain,
 		"externalNetworkID":    *p.cluster.Spec.Openstack.ExternalNetworkID,
+	}
+
+	if p.cluster.Spec.Openstack.CACert != nil {
+		openstackValues["ca"] = base64.StdEncoding.EncodeToString(*p.cluster.Spec.Openstack.CACert)
 	}
 
 	if p.cluster.Spec.Openstack.SSHKeyName != nil {

--- a/pkg/server/authorization/keystone/keystone.go
+++ b/pkg/server/authorization/keystone/keystone.go
@@ -40,12 +40,6 @@ type Options struct {
 	// Endpoint is the Keystone Endpoint.
 	Endpoint string
 
-	// CACertificate is ONLY used in testing, in production we simply Dial the
-	// endpoint and extract it as this will actually pickup CA rotations.
-	// Having this set will inhibit that behaviour.  This is a PEM encoded
-	// certificate if you were to every use it...
-	CACertificate []byte
-
 	// Domain is the default domain users live under.
 	Domain string
 
@@ -83,10 +77,6 @@ func (a *Authenticator) Endpoint() string {
 // TODO: It stands to reason that the user should supply this in future.
 func (a *Authenticator) Domain() string {
 	return a.options.Domain
-}
-
-func (a *Authenticator) CACertificate() []byte {
-	return a.options.CACertificate
 }
 
 // OIDCTokenExchangeResult is what's returned by Keystone when we give it an OIDC

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -256,7 +256,6 @@ func mustSetupUnikornServer(t *testing.T, openstack net.Addr, client client.With
 
 	// Override any flag defaults we need to.
 	s.Options.RequestTimeout = 0
-	s.KeystoneOptions.CACertificate = []byte("it's fake mon")
 
 	if debug {
 		s.SetupLogging()

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -18,13 +18,10 @@ package util
 
 import (
 	"context"
-	"crypto/tls"
 	"encoding/json"
-	"encoding/pem"
 	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 )
 
 // natPrefix provides a cache/memoization for GetNATPrefix, be nice to our
@@ -70,32 +67,6 @@ func GetNATPrefix(ctx context.Context) (string, error) {
 	natPrefix = fmt.Sprintf("%s/32", natAddress.IP)
 
 	return natPrefix, nil
-}
-
-// GetURLCACertificate works out the CA certificate for a HTTPS endpoint.
-func GetURLCACertificate(host string) ([]byte, error) {
-	authURL, err := url.Parse(host)
-	if err != nil {
-		return nil, err
-	}
-
-	conn, err := tls.Dial("tcp", authURL.Host, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	defer conn.Close()
-
-	chains := conn.ConnectionState().VerifiedChains
-	chain := chains[0]
-	ca := chain[len(chain)-1]
-
-	pemBlock := &pem.Block{
-		Type:  "CERTIFICATE",
-		Bytes: ca.Raw,
-	}
-
-	return pem.EncodeToMemory(pemBlock), nil
 }
 
 // Keys returns the keys from a string map.


### PR DESCRIPTION
This means we can make use of implicit CA certificates, and cut out a load of crap code.  Also includes a heap of bug fixes.