### PR TITLE
Version 0.3.51

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Consult the [developer documentation](DEVELOPER.md) for local development instru
 Download the official binary (update the version as appropriate):
 
 ```shell
-wget -O ~/bin/unikornctl https://github.com/eschercloudai/unikorn/releases/download/0.3.50/unikornctl-linux-amd64
+wget -O ~/bin/unikornctl https://github.com/eschercloudai/unikorn/releases/download/0.3.51/unikornctl-linux-amd64
 ```
 
 ### Set up shell completion
@@ -232,7 +232,7 @@ spec:
   source:
     path: charts/unikorn
     repoURL: git@github.com:eschercloudai/unikorn
-    targetRevision: 0.3.50
+    targetRevision: 0.3.51
     helm:
       parameters:
       - name: dockerConfig

--- a/charts/unikorn/Chart.yaml
+++ b/charts/unikorn/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for deploying Unikorn
 
 type: application
 
-version: 0.3.50
-appVersion: 0.3.50
+version: 0.3.51
+appVersion: 0.3.51
 
 icon: https://raw.githubusercontent.com/eschercloudai/unikorn/main/icons/default.png


### PR DESCRIPTION
Highlights:

* Upgraded libraries, toolchain and linter.
* Controller unification and unit testing.
* Application inference in the application provisioner, this now takes the application name and looks up the application, rather than delegating it to the client.
* Inheritance of provisioner options. You can now set the remote and cleanup semantics at the "group" level, and they will propagate.
* Post provision application hook. Provides a cleaner interface when a provisioner needs to do some cleanup work.
* Moved a bunch of code out of the way, and deleted a bunch of unused stuff.
* CD driver initialisation is done at the controller level, not per provisioner, and is also dynamic.
* Upgrade CAPO to 0.8.0 to reap the benefits of a bunch of fixes.