### PR TITLE
Make image signing optional

### DIFF
--- a/charts/unikorn/templates/unikorn-server.yaml
+++ b/charts/unikorn/templates/unikorn-server.yaml
@@ -111,6 +111,9 @@ spec:
         image: {{ include "unikorn.serverImage" . }}
         args:
         - --image-signing-key={{ .Values.server.imageSigningKey }}
+        {{- with $properties := .Values.server.imageProperties -}}
+          {{ printf "- --image-properties=%s" (join "," $properties) | nindent 8 }}
+        {{- end }}
         {{- with $credentials := .Values.server.applicationCredentials -}}
           {{- with $roles := $credentials.roles -}}
             {{ printf "- --application-credential-roles=%s" (join "," $roles) | nindent 8 }}

--- a/charts/unikorn/values.yaml
+++ b/charts/unikorn/values.yaml
@@ -81,6 +81,11 @@ server:
   # managed by vault.
   imageSigningKey: LS0tLS1CRUdJTiBQVUJMSUMgS0VZLS0tLS0KTUhZd0VBWUhLb1pJemowQ0FRWUZLNEVFQUNJRFlnQUVmOGs4RVY1TUg4M1BncThYd0JGUTd5YkU2NTEzRlh0awpHaG1jalp4WmYzbU5QOE0vb3VBbE0vZHdYWGpFeXZTNlJhVHdoT3A0aTdHL3VvbE5ZL0RJSCt1elc2VXNxR3VHClFpSW11Tm9BdzFSS1NQcEtyNWlJVXU2eEc1cDR3U3E5Ci0tLS0tRU5EIFBVQkxJQyBLRVktLS0tLQo=
 
+  # Whether to filter based on the 'k8s' and 'gpu' image properties used to derive versions
+  imageProperties:
+  - k8s
+  - gpu
+
   keystone:
     endpoint: "https://nl1.eschercloud.com:5000"
     userDomain: "Default"

--- a/pkg/cmd/util/completion/openstack.go
+++ b/pkg/cmd/util/completion/openstack.go
@@ -131,7 +131,7 @@ func OpenstackImageCompletionFunc(cloud *string) func(*cobra.Command, []string, 
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}
 
-		results, err := client.Images(context.Background(), nil)
+		results, err := client.Images(context.Background(), nil, nil)
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveNoFileComp
 		}

--- a/pkg/server/handler/providers/openstack/openstack.go
+++ b/pkg/server/handler/providers/openstack/openstack.go
@@ -436,10 +436,10 @@ func (w imageSortWrapper) Swap(i, j int) {
 func (o *Openstack) ListImages(r *http.Request) (generated.OpenstackImages, error) {
 	client, err := o.ImageClient(r)
 	if err != nil {
-		return nil, errors.OAuth2ServerError("failed get compute client").WithError(err)
+		return nil, errors.OAuth2ServerError("failed get image client").WithError(err)
 	}
 
-	result, err := client.Images(r.Context(), o.options.Key.key)
+	result, err := client.Images(r.Context(), o.options.Key.key, o.options.Properties)
 	if err != nil {
 		return nil, covertError(err)
 	}
@@ -447,16 +447,8 @@ func (o *Openstack) ListImages(r *http.Request) (generated.OpenstackImages, erro
 	images := make(generated.OpenstackImages, len(result))
 
 	for i, image := range result {
-		// images are pre-filtered by the provider library, so these keys exist.
-		kubernetesVersion, ok := image.Properties["k8s"].(string)
-		if !ok {
-			return nil, errors.OAuth2ServerError("failed parse image kubernetes version")
-		}
-
-		nvidiaDriverVersion, ok := image.Properties["gpu"].(string)
-		if !ok {
-			return nil, errors.OAuth2ServerError("failed parse image gpu driver version")
-		}
+		kubernetesVersion, _ := image.Properties["k8s"].(string)
+		nvidiaDriverVersion, _ := image.Properties["gpu"].(string)
 
 		images[i].Id = image.ID
 		images[i].Name = image.Name

--- a/pkg/server/handler/providers/openstack/options.go
+++ b/pkg/server/handler/providers/openstack/options.go
@@ -47,6 +47,10 @@ type PublicKeyVar struct {
 
 // Set accepts a base64 encoded PEM public key and tries to decode it.
 func (v *PublicKeyVar) Set(s string) error {
+	if s == "" {
+		return nil
+	}
+
 	pemString, err := base64.StdEncoding.DecodeString(s)
 	if err != nil {
 		return err
@@ -88,6 +92,7 @@ type Options struct {
 	ComputeOptions    openstack.ComputeOptions
 	Key               PublicKeyVar
 	ServerGroupPolicy string
+	Properties        []string
 	// applicationCredentialRoles sets the roles an application credential
 	// is granted on creation.
 	ApplicationCredentialRoles []string
@@ -96,6 +101,7 @@ type Options struct {
 func (o *Options) AddFlags(f *pflag.FlagSet) {
 	o.ComputeOptions.AddFlags(f)
 	f.Var(&o.Key, "image-signing-key", "Key used to verify valid images for use with the platform")
+	f.StringSliceVar(&o.Properties, "image-properties", nil, "Properties used to filter the list of images")
 	f.StringVar(&o.ServerGroupPolicy, "server-group-policy", "soft-anti-affinity", "Scheduling policy to use for server groups")
 	f.StringSliceVar(&o.ApplicationCredentialRoles, "application-credential-roles", nil, "A role to be added to application credentials on creation.  May be specified more than once.")
 }


### PR DESCRIPTION
Filter and verify signed images only if the server is started with the relevant option.  Otherwise assume that if it has the 'k8s' property set then it's a Kubernetes image that Unikorn can use to provision a cluster.