### PR TITLE
Version 0.3.52

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Consult the [developer documentation](DEVELOPER.md) for local development instru
 Download the official binary (update the version as appropriate):
 
 ```shell
-wget -O ~/bin/unikornctl https://github.com/eschercloudai/unikorn/releases/download/0.3.51/unikornctl-linux-amd64
+wget -O ~/bin/unikornctl https://github.com/eschercloudai/unikorn/releases/download/0.3.52/unikornctl-linux-amd64
 ```
 
 ### Set up shell completion
@@ -232,7 +232,7 @@ spec:
   source:
     path: charts/unikorn
     repoURL: git@github.com:eschercloudai/unikorn
-    targetRevision: 0.3.51
+    targetRevision: 0.3.52
     helm:
       parameters:
       - name: dockerConfig

--- a/charts/unikorn/Chart.yaml
+++ b/charts/unikorn/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for deploying Unikorn
 
 type: application
 
-version: 0.3.51
-appVersion: 0.3.51
+version: 0.3.52
+appVersion: 0.3.52
 
 icon: https://raw.githubusercontent.com/eschercloudai/unikorn/main/icons/default.png

--- a/charts/unikorn/templates/applicationbundles.yaml
+++ b/charts/unikorn/templates/applicationbundles.yaml
@@ -17,7 +17,7 @@ spec:
   - name: cluster-api
     reference:
       kind: HelmApplication
-      name: cluster-api-0.1.9-1
+      name: cluster-api-0.1.10-1
 ---
 apiVersion: unikorn.eschercloud.ai/v1alpha1
 kind: ApplicationBundle
@@ -39,7 +39,7 @@ spec:
   - name: cluster-api
     reference:
       kind: HelmApplication
-      name: cluster-api-0.1.9-1
+      name: cluster-api-0.1.10-1
 ---
 apiVersion: unikorn.eschercloud.ai/v1alpha1
 kind: ApplicationBundle

--- a/charts/unikorn/templates/applications.yaml
+++ b/charts/unikorn/templates/applications.yaml
@@ -65,12 +65,12 @@ spec:
 apiVersion: unikorn.eschercloud.ai/v1alpha1
 kind: HelmApplication
 metadata:
-  name: cluster-api-0.1.9-1
+  name: cluster-api-0.1.10-1
 spec:
   repo: https://github.com/eschercloudai/helm-cluster-api
   repo: https://eschercloudai.github.io/helm-cluster-api
   chart: cluster-api
-  version: v0.1.9
+  version: v0.1.10
   interface: 1.0.0
 ---
 apiVersion: unikorn.eschercloud.ai/v1alpha1


### PR DESCRIPTION
Highlights:

* New chart for CAPI/CAPO as the old registry no longer gets new images, I got caught out by local development images...