### PR TITLE
Implicit Client Scoping

### DIFF
--- a/pkg/client/context.go
+++ b/pkg/client/context.go
@@ -24,14 +24,27 @@ import (
 
 type key int
 
-//nolint:gochecknoglobals
-var clientKey key
+const (
+	// staticClientKey is the client that is scoped to the static cluster.
+	staticClientKey key = iota
 
-func NewContext(ctx context.Context, client client.Client) context.Context {
-	return context.WithValue(ctx, clientKey, client)
+	// dynamicClientKey is the current client that is scoped to the current remote cluster.
+	dynamicClientKey
+)
+
+func NewContextWithStaticClient(ctx context.Context, client client.Client) context.Context {
+	return context.WithValue(ctx, staticClientKey, client)
 }
 
-func FromContext(ctx context.Context) client.Client {
+func StaticClientFromContext(ctx context.Context) client.Client {
 	//nolint:forcetypeassert
-	return ctx.Value(clientKey).(client.Client)
+	return ctx.Value(staticClientKey).(client.Client)
+}
+func NewContextWithDynamicClient(ctx context.Context, client client.Client) context.Context {
+	return context.WithValue(ctx, dynamicClientKey, client)
+}
+
+func DynamicClientFromContext(ctx context.Context) client.Client {
+	//nolint:forcetypeassert
+	return ctx.Value(dynamicClientKey).(client.Client)
 }

--- a/pkg/managers/common/reconcile.go
+++ b/pkg/managers/common/reconcile.go
@@ -99,8 +99,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	// TODO: make a composite interface type.
 	resource, _ := object.(application.OwningResource)
 
-	ctx = clientlib.NewContext(ctx, r.client)
+	// The static client is used by the application provisioner to get access to
+	// application bundles and definitions regardless of remote cluster scoping etc.
+	ctx = clientlib.NewContextWithStaticClient(ctx, r.client)
+
+	// The dynamic client context is updated as remote clusters are descended into.
+	ctx = clientlib.NewContextWithDynamicClient(ctx, r.client)
+
+	// The driver context is updated as remote provisioners are descended into.
 	ctx = cd.NewContext(ctx, driver)
+
+	// The application context contains a reference to the resource that caused
+	// their creation.
 	ctx = application.NewContext(ctx, resource)
 
 	// See if the object exists or not, if not it's been deleted.

--- a/pkg/provisioners/application/provisioner_test.go
+++ b/pkg/provisioners/application/provisioner_test.go
@@ -153,7 +153,7 @@ func TestApplicationCreateHelm(t *testing.T) {
 	owner := &mutuallyExclusiveResource{}
 
 	ctx := context.Background()
-	ctx = clientlib.NewContext(ctx, tc.client)
+	ctx = clientlib.NewContextWithStaticClient(ctx, tc.client)
 	ctx = cd.NewContext(ctx, driver)
 	ctx = application.NewContext(ctx, owner)
 
@@ -254,7 +254,7 @@ func TestApplicationCreateHelmExtended(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	ctx = clientlib.NewContext(ctx, tc.client)
+	ctx = clientlib.NewContextWithStaticClient(ctx, tc.client)
 	ctx = cd.NewContext(ctx, driver)
 	ctx = application.NewContext(ctx, owner)
 
@@ -303,7 +303,7 @@ func TestApplicationCreateGit(t *testing.T) {
 	owner := &mutuallyExclusiveResource{}
 
 	ctx := context.Background()
-	ctx = clientlib.NewContext(ctx, tc.client)
+	ctx = clientlib.NewContextWithStaticClient(ctx, tc.client)
 	ctx = cd.NewContext(ctx, driver)
 	ctx = application.NewContext(ctx, owner)
 
@@ -430,7 +430,7 @@ func TestApplicationCreateMutate(t *testing.T) {
 	owner := &mutuallyExclusiveResource{}
 
 	ctx := context.Background()
-	ctx = clientlib.NewContext(ctx, tc.client)
+	ctx = clientlib.NewContextWithStaticClient(ctx, tc.client)
 	ctx = cd.NewContext(ctx, driver)
 	ctx = application.NewContext(ctx, owner)
 

--- a/pkg/provisioners/helmapplications/openstackplugincindercsi/provisioner.go
+++ b/pkg/provisioners/helmapplications/openstackplugincindercsi/provisioner.go
@@ -21,7 +21,7 @@ import (
 	"strings"
 
 	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
-	"github.com/eschercloudai/unikorn/pkg/client"
+	clientlib "github.com/eschercloudai/unikorn/pkg/client"
 	"github.com/eschercloudai/unikorn/pkg/constants"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/application"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/helmapplications/openstackcloudprovider"
@@ -87,7 +87,7 @@ func (p *Provisioner) Values(ctx context.Context, version *string) (interface{},
 	//nolint:forcetypeassert
 	cluster := application.FromContext(ctx).(*unikornv1.KubernetesCluster)
 
-	client := client.FromContext(ctx)
+	client := clientlib.DynamicClientFromContext(ctx)
 
 	storageClasses := p.generateStorageClasses(cluster)
 

--- a/pkg/provisioners/helmapplications/vcluster/config.go
+++ b/pkg/provisioners/helmapplications/vcluster/config.go
@@ -102,7 +102,7 @@ func (c *ControllerRuntimeClient) GetSecret(ctx context.Context, namespace, name
 	log := log.FromContext(ctx)
 
 	secret := &corev1.Secret{}
-	if err := clientlib.FromContext(ctx).Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, secret); err != nil {
+	if err := clientlib.DynamicClientFromContext(ctx).Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, secret); err != nil {
 		if kerrors.IsNotFound(err) {
 			log.Info("vitual cluster kubeconfig does not exist, yielding")
 

--- a/pkg/provisioners/managers/controlplane/provisioner.go
+++ b/pkg/provisioners/managers/controlplane/provisioner.go
@@ -118,7 +118,7 @@ func (p *Provisioner) provisionNamespace(ctx context.Context) (*corev1.Namespace
 
 // deprovisionClusters removes any kubernetes clusters, and frees up OpenStack resources.
 func (p *Provisioner) deprovisionClusters(ctx context.Context, namespace string) error {
-	c := clientlib.FromContext(ctx)
+	c := clientlib.StaticClientFromContext(ctx)
 
 	clusters := &unikornv1.KubernetesClusterList{}
 	if err := c.List(ctx, clusters, &client.ListOptions{Namespace: namespace}); err != nil {

--- a/pkg/provisioners/resource/resource.go
+++ b/pkg/provisioners/resource/resource.go
@@ -58,7 +58,8 @@ func mutate() error {
 // Provision implements the Provision interface.
 func (p *Provisioner) Provision(ctx context.Context) error {
 	log := log.FromContext(ctx)
-	c := clientlib.FromContext(ctx)
+
+	c := clientlib.DynamicClientFromContext(ctx)
 
 	objectKey := client.ObjectKeyFromObject(p.resource)
 
@@ -77,7 +78,8 @@ func (p *Provisioner) Provision(ctx context.Context) error {
 // Deprovision implements the Provision interface.
 func (p *Provisioner) Deprovision(ctx context.Context) error {
 	log := log.FromContext(ctx)
-	c := clientlib.FromContext(ctx)
+
+	c := clientlib.DynamicClientFromContext(ctx)
 
 	objectKey := client.ObjectKeyFromObject(p.resource)
 

--- a/pkg/provisioners/util/unbundler.go
+++ b/pkg/provisioners/util/unbundler.go
@@ -81,7 +81,7 @@ func (u *Unbundler) AddApplication(r **unikornv1.HelmApplication, name string, o
 }
 
 func (u *Unbundler) Unbundle(ctx context.Context) error {
-	c := clientlib.FromContext(ctx)
+	c := clientlib.StaticClientFromContext(ctx)
 
 	key := client.ObjectKey{
 		Name: u.name,

--- a/pkg/provisioners/util/util.go
+++ b/pkg/provisioners/util/util.go
@@ -36,7 +36,7 @@ var (
 )
 
 func GetResourceNamespace(ctx context.Context, l labels.Set) (*corev1.Namespace, error) {
-	c := clientlib.FromContext(ctx)
+	c := clientlib.StaticClientFromContext(ctx)
 
 	namespaces := &corev1.NamespaceList{}
 	if err := c.List(ctx, namespaces, &client.ListOptions{LabelSelector: l.AsSelector()}); err != nil {

--- a/pkg/server/handler/cluster/client.go
+++ b/pkg/server/handler/cluster/client.go
@@ -132,7 +132,7 @@ func (c *Client) GetKubeconfig(ctx context.Context, controlPlaneName generated.C
 
 	// TODO: propagate the client like we do in the controllers, then code sharing
 	// becomes a lot easier!
-	ctx = clientlib.NewContext(ctx, c.client)
+	ctx = clientlib.NewContextWithDynamicClient(ctx, c.client)
 
 	vc := vcluster.NewControllerRuntimeClient()
 


### PR DESCRIPTION
Previously various bits and bobs needed to create clients and have explicit knowledege of topology (criminal) and even implementation details (even more criminal).  What we should do is update the clients as the scope changes, so as we enter into a new remote cluster, the client is also updated to interact with it.  This also handles nesting which is even cooler.  The only real caveats here are we need a distinction between a dynamic client (that changes as the scope does) and a static one (that always points at the base cluster e.g. for access to application bundles etc).  Also, this requires some better handing of deprovisioning as we're now creating clients unconditionally when they previously would have been lazily created.