### PR TITLE
Version 0.3.53

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Unikorn is split up into domain specific micro-services:
 Download the official binary (update the version as appropriate):
 
 ```shell
-wget -O ~/bin/unikornctl https://github.com/eschercloudai/unikorn/releases/download/0.3.52/unikornctl-linux-amd64
+wget -O ~/bin/unikornctl https://github.com/eschercloudai/unikorn/releases/download/0.3.53/unikornctl-linux-amd64
 ```
 
 ### Set up shell completion
@@ -230,7 +230,7 @@ spec:
   source:
     path: charts/unikorn
     repoURL: git@github.com:eschercloudai/unikorn
-    targetRevision: 0.3.52
+    targetRevision: 0.3.53
     helm:
       parameters:
       - name: dockerConfig

--- a/charts/unikorn/Chart.yaml
+++ b/charts/unikorn/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for deploying Unikorn
 
 type: application
 
-version: 0.3.52
-appVersion: 0.3.52
+version: 0.3.53
+appVersion: 0.3.53
 
 icon: https://raw.githubusercontent.com/eschercloudai/unikorn/main/icons/default.png


### PR DESCRIPTION
Highlights:

* Propagation of various common components via the context e.g. clients, drivers, etc.
* Make remote provisioners implicitly create themselves, and have them provision subordinate provisioners within that context.
* Use declarative ArgoCD remote cluster provisioning to remove the API access entirely, along with all the pain to do with networking and authentication.
* Make image validation optional.
* Improve Ingress HA.
* Remove driver initialisation from controller start up.
* Clients now change as the scope changes e.g. remote cluster, so provisioners don't need to know about topoology or technology.
* Architectural documentation.
* Allow NV operator not to be installed.