### PR TITLE
Allow Reconcilers to be Paused

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -1,0 +1,32 @@
+name: Unikorn Merge
+on:
+  push:
+    branches:
+    - main
+    tags-ignore:
+    - '*'
+env:
+  GO_VERSION: 1.21.1
+jobs:
+  Code Coverage:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Setup Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: ${{ env.GO_VERSION }}
+        cache: true
+    - name: Install Helm
+      uses: azure/setup-helm@v3
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Touch
+      run: make touch
+    - name: Unit Test
+      run: make test-unit
+    - name: Run Codecov
+      uses: codecov/codecov-action@v3
+      env:
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/charts/unikorn/crds/unikorn.eschercloud.ai_controlplanes.yaml
+++ b/charts/unikorn/crds/unikorn.eschercloud.ai_controlplanes.yaml
@@ -232,6 +232,9 @@ spec:
                         type: object
                     type: object
                 type: object
+              pause:
+                description: Pause, if true, will inhibit reconciliation.
+                type: boolean
               timeout:
                 default: 10m
                 description: Timeout defines how long a control plane is allowed to

--- a/charts/unikorn/crds/unikorn.eschercloud.ai_kubernetesclusters.yaml
+++ b/charts/unikorn/crds/unikorn.eschercloud.ai_kubernetesclusters.yaml
@@ -406,6 +406,9 @@ spec:
                 - externalNetworkId
                 - failureDomain
                 type: object
+              pause:
+                description: Pause, if true, will inhibit reconciliation.
+                type: boolean
               timeout:
                 default: 20m
                 description: Timeout is the maximum time to attempt to provision a

--- a/charts/unikorn/crds/unikorn.eschercloud.ai_projects.yaml
+++ b/charts/unikorn/crds/unikorn.eschercloud.ai_projects.yaml
@@ -46,6 +46,10 @@ spec:
             type: object
           spec:
             description: ProjectSpec defines project specific metadata.
+            properties:
+              pause:
+                description: Pause, if true, will inhibit reconciliation.
+                type: boolean
             type: object
           status:
             description: ProjectStatus defines the status of the project.

--- a/pkg/apis/unikorn/v1alpha1/helpers.go
+++ b/pkg/apis/unikorn/v1alpha1/helpers.go
@@ -51,22 +51,20 @@ func IPv4AddressSliceFromIPSlice(in []net.IP) []IPv4Address {
 	return out
 }
 
-// ConditionResource is an API type that has a set of conditions.
-type ConditionResource interface {
-	// LookupCondition scans the status conditions for an existing condition
-	// whose type matches.
-	LookupCondition(t ConditionType) (*Condition, error)
-
-	// UpdateCondition either adds or updates a condition in the control plane
-	// status. If the condition, status and message match an existing condition
-	// the update is ignored.
-	UpdateCondition(t ConditionType, status corev1.ConditionStatus, reason ConditionReason, message string)
+// Paused implements the ReconcilePauser interface.
+func (c *Project) Paused() bool {
+	return c.Spec.Pause
 }
 
-// These resources have managers, and must implment this generic interface.
-var _ ConditionResource = &Project{}
-var _ ConditionResource = &ControlPlane{}
-var _ ConditionResource = &KubernetesCluster{}
+// Paused implements the ReconcilePauser interface.
+func (c *ControlPlane) Paused() bool {
+	return c.Spec.Pause
+}
+
+// Paused implements the ReconcilePauser interface.
+func (c *KubernetesCluster) Paused() bool {
+	return c.Spec.Pause
+}
 
 // getCondition is a generic condition lookup function.
 func getCondition(conditions []Condition, t ConditionType) (*Condition, error) {
@@ -108,16 +106,16 @@ func updateCondition(conditions *[]Condition, t ConditionType, status corev1.Con
 	}
 }
 
-// LookupCondition scans the status conditions for an existing condition whose type
+// StatusConditionRead scans the status conditions for an existing condition whose type
 // matches.
-func (c *Project) LookupCondition(t ConditionType) (*Condition, error) {
+func (c *Project) StatusConditionRead(t ConditionType) (*Condition, error) {
 	return getCondition(c.Status.Conditions, t)
 }
 
-// UpdateCondition either adds or updates a condition in the control plane status.
+// StatusConditionWrite either adds or updates a condition in the control plane status.
 // If the condition, status and message match an existing condition the update is
 // ignored.
-func (c *Project) UpdateCondition(t ConditionType, status corev1.ConditionStatus, reason ConditionReason, message string) {
+func (c *Project) StatusConditionWrite(t ConditionType, status corev1.ConditionStatus, reason ConditionReason, message string) {
 	updateCondition(&c.Status.Conditions, t, status, reason, message)
 }
 
@@ -132,16 +130,24 @@ func (c *Project) ResourceLabels() (labels.Set, error) {
 	return labels, nil
 }
 
-// LookupCondition scans the status conditions for an existing condition whose type
+func (c *Project) ApplicationBundleKind() ApplicationBundleResourceKind {
+	return ""
+}
+
+func (c *Project) ApplicationBundleName() string {
+	return ""
+}
+
+// StatusConditionRead scans the status conditions for an existing condition whose type
 // matches.
-func (c *ControlPlane) LookupCondition(t ConditionType) (*Condition, error) {
+func (c *ControlPlane) StatusConditionRead(t ConditionType) (*Condition, error) {
 	return getCondition(c.Status.Conditions, t)
 }
 
-// UpdateCondition either adds or updates a condition in the control plane status.
+// StatusConditionWrite either adds or updates a condition in the control plane status.
 // If the condition, status and message match an existing condition the update is
 // ignored.
-func (c *ControlPlane) UpdateCondition(t ConditionType, status corev1.ConditionStatus, reason ConditionReason, message string) {
+func (c *ControlPlane) StatusConditionWrite(t ConditionType, status corev1.ConditionStatus, reason ConditionReason, message string) {
 	updateCondition(&c.Status.Conditions, t, status, reason, message)
 }
 
@@ -178,16 +184,16 @@ func (c ControlPlane) UpgradeSpec() *ApplicationBundleAutoUpgradeSpec {
 	return c.Spec.ApplicationBundleAutoUpgrade
 }
 
-// LookupCondition scans the status conditions for an existing condition whose type
+// StatusConditionRead scans the status conditions for an existing condition whose type
 // matches.
-func (c *KubernetesCluster) LookupCondition(t ConditionType) (*Condition, error) {
+func (c *KubernetesCluster) StatusConditionRead(t ConditionType) (*Condition, error) {
 	return getCondition(c.Status.Conditions, t)
 }
 
-// UpdateCondition either adds or updates a condition in the cluster status.
+// StatusConditionWrite either adds or updates a condition in the cluster status.
 // If the condition, status and message match an existing condition the update is
 // ignored.
-func (c *KubernetesCluster) UpdateCondition(t ConditionType, status corev1.ConditionStatus, reason ConditionReason, message string) {
+func (c *KubernetesCluster) StatusConditionWrite(t ConditionType, status corev1.ConditionStatus, reason ConditionReason, message string) {
 	updateCondition(&c.Status.Conditions, t, status, reason, message)
 }
 

--- a/pkg/apis/unikorn/v1alpha1/interfaces.go
+++ b/pkg/apis/unikorn/v1alpha1/interfaces.go
@@ -17,14 +17,17 @@ limitations under the License.
 package v1alpha1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// MutuallyExclusiveResource is a generic interface over all resource types,
+// ResourceLabeller is a generic interface over all resource types,
 // where the resource can be uniquely identified.  As these typically map to
 // custom resource types, be extra careful you don't overload anything in
 // metav1.Object or runtime.Object.
-type MutuallyExclusiveResource interface {
+type ResourceLabeller interface {
 	// ResourceLabels returns a set of labels from the resource that uniquely
 	// identify it, if they all were to reside in the same namespace.
 	// In database terms this would be a composite key.
@@ -33,7 +36,40 @@ type MutuallyExclusiveResource interface {
 
 // ApplicationBundleGetter is a type, typically a custom resource, that has an attached
 // application bundle.
+// TODO: make this a KindNamer that's attached to the resource remote reference.
 type ApplicationBundleGetter interface {
 	ApplicationBundleKind() ApplicationBundleResourceKind
 	ApplicationBundleName() string
+}
+
+// ReconcilePauser indicates a resource can have its reconciliation paused.
+type ReconcilePauser interface {
+	// Paused indicates a resource is paused and will not do anything.
+	Paused() bool
+}
+
+// StatusConditionReader allows generic status conditions to be read.
+type StatusConditionReader interface {
+	// StatusConditionRead scans the status conditions for an existing condition
+	// whose type matches.
+	StatusConditionRead(t ConditionType) (*Condition, error)
+}
+
+// StatusConditionWriter allows generic status conditions to be updated.
+type StatusConditionWriter interface {
+	// StatusConditionWrite either adds or updates a condition in the control plane
+	// status. If the condition, status and message match an existing condition
+	// the update is ignored.
+	StatusConditionWrite(t ConditionType, status corev1.ConditionStatus, reason ConditionReason, message string)
+}
+
+// ManagableResourceInterface is a resource type that can be manged e.g. has a
+// controller associateds with it.
+type ManagableResourceInterface interface {
+	client.Object
+	ResourceLabeller
+	ApplicationBundleGetter
+	ReconcilePauser
+	StatusConditionReader
+	StatusConditionWriter
 }

--- a/pkg/apis/unikorn/v1alpha1/types.go
+++ b/pkg/apis/unikorn/v1alpha1/types.go
@@ -233,6 +233,8 @@ type Project struct {
 
 // ProjectSpec defines project specific metadata.
 type ProjectSpec struct {
+	// Pause, if true, will inhibit reconciliation.
+	Pause bool `json:"pause,omitempty"`
 }
 
 // ProjectStatus defines the status of the project.
@@ -272,6 +274,8 @@ type ControlPlane struct {
 
 // ControlPlaneSpec defines any control plane specific options.
 type ControlPlaneSpec struct {
+	// Pause, if true, will inhibit reconciliation.
+	Pause bool `json:"pause,omitempty"`
 	// Timeout defines how long a control plane is allowed to provision for before
 	// a timeout is triggerd and the request aborts.
 	// +kubebuilder:default="10m"
@@ -424,6 +428,8 @@ type KubernetesCluster struct {
 
 // KubernetesClusterSpec defines the requested state of the Kubernetes cluster.
 type KubernetesClusterSpec struct {
+	// Pause, if true, will inhibit reconciliation.
+	Pause bool `json:"pause,omitempty"`
 	// Timeout is the maximum time to attempt to provision a cluster before aborting.
 	// +kubebuilder:default="20m"
 	Timeout *metav1.Duration `json:"timeout"`

--- a/pkg/managers/common/reconcile_test.go
+++ b/pkg/managers/common/reconcile_test.go
@@ -102,10 +102,10 @@ func newRequest(namespace, name string) reconcile.Request {
 
 // mustAssertStatus checks the status is as we expect.  Very rudimentary as we only support
 // the Available status.
-func mustAssertStatus(t *testing.T, resource unikornv1.ConditionResource, status corev1.ConditionStatus, reason unikornv1.ConditionReason) {
+func mustAssertStatus(t *testing.T, resource unikornv1.StatusConditionReader, status corev1.ConditionStatus, reason unikornv1.ConditionReason) {
 	t.Helper()
 
-	condition, err := resource.LookupCondition(unikornv1.ConditionAvailable)
+	condition, err := resource.StatusConditionRead(unikornv1.ConditionAvailable)
 	assert.NoError(t, err)
 
 	if condition != nil {

--- a/pkg/provisioners/application/context.go
+++ b/pkg/provisioners/application/context.go
@@ -18,6 +18,8 @@ package application
 
 import (
 	"context"
+
+	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
 )
 
 type key int
@@ -25,11 +27,11 @@ type key int
 //nolint:gochecknoglobals
 var resourceKey key
 
-func NewContext(ctx context.Context, resource OwningResource) context.Context {
+func NewContext(ctx context.Context, resource unikornv1.ManagableResourceInterface) context.Context {
 	return context.WithValue(ctx, resourceKey, resource)
 }
 
-func FromContext(ctx context.Context) OwningResource {
+func FromContext(ctx context.Context) unikornv1.ManagableResourceInterface {
 	//nolint:forcetypeassert
-	return ctx.Value(resourceKey).(OwningResource)
+	return ctx.Value(resourceKey).(unikornv1.ManagableResourceInterface)
 }

--- a/pkg/provisioners/application/interfaces.go
+++ b/pkg/provisioners/application/interfaces.go
@@ -19,19 +19,8 @@ package application
 import (
 	"context"
 
-	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
 	"github.com/eschercloudai/unikorn/pkg/cd"
 )
-
-// OwningResource defines the interfaces an owning resource has to implement
-// to support application deployment.
-type OwningResource interface {
-	// The resource must contain an getter to access it's catalog of applications.
-	unikornv1.ApplicationBundleGetter
-
-	// The resource must be able to uniquely identify an application.
-	unikornv1.MutuallyExclusiveResource
-}
 
 // ReleaseNamer is an interface that allows generators to supply an implicit release
 // name to Helm.

--- a/pkg/provisioners/application/provisioner.go
+++ b/pkg/provisioners/application/provisioner.go
@@ -18,11 +18,13 @@ package application
 
 import (
 	"context"
+	"slices"
 
 	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
 	"github.com/eschercloudai/unikorn/pkg/cd"
 	"github.com/eschercloudai/unikorn/pkg/provisioners"
 	"github.com/eschercloudai/unikorn/pkg/provisioners/util"
+	uutil "github.com/eschercloudai/unikorn/pkg/util"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -103,10 +105,14 @@ func (p *Provisioner) getResourceID(ctx context.Context) (*cd.ResourceIdentifier
 	if len(l) > 0 {
 		id.Labels = make([]cd.ResourceIdentifierLabel, 0, len(l))
 
-		for k, v := range l {
+		// Make label ordering deterministic for the sake of testing...
+		k := uutil.Keys(l)
+		slices.Sort(k)
+
+		for _, key := range k {
 			id.Labels = append(id.Labels, cd.ResourceIdentifierLabel{
-				Name:  k,
-				Value: v,
+				Name:  key,
+				Value: l[key],
 			})
 		}
 	}

--- a/pkg/provisioners/helmapplications/vcluster/remotecluster.go
+++ b/pkg/provisioners/helmapplications/vcluster/remotecluster.go
@@ -31,26 +31,26 @@ type RemoteCluster struct {
 	// namespace tells us where the vcluster lives.
 	namespace string
 
-	// resource is used to identify the owner of and uniquely identify
+	// labeller is used to identify the owner of and uniquely identify
 	// a remote cluster instance.
-	resource unikornv1.MutuallyExclusiveResource
+	labeller unikornv1.ResourceLabeller
 }
 
 // Ensure this implements the remotecluster.Generator interface.
 var _ provisioners.RemoteCluster = &RemoteCluster{}
 
 // NewRemoteCluster return a new instance of a remote cluster generator.
-func NewRemoteCluster(namespace string, resource unikornv1.MutuallyExclusiveResource) *RemoteCluster {
+func NewRemoteCluster(namespace string, labeller unikornv1.ResourceLabeller) *RemoteCluster {
 	return &RemoteCluster{
 		namespace: namespace,
-		resource:  resource,
+		labeller:  labeller,
 	}
 }
 
 // ID implements the remotecluster.Generator interface.
 func (g *RemoteCluster) ID() *cd.ResourceIdentifier {
 	// TODO: error checking.
-	resourceLabels, _ := g.resource.ResourceLabels()
+	resourceLabels, _ := g.labeller.ResourceLabels()
 
 	var labels []cd.ResourceIdentifierLabel
 

--- a/pkg/provisioners/interfaces.go
+++ b/pkg/provisioners/interfaces.go
@@ -21,11 +21,10 @@ package provisioners
 import (
 	"context"
 
+	unikornv1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
 	"github.com/eschercloudai/unikorn/pkg/cd"
 
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // Generator is an abstraction around the sources of remote
@@ -75,5 +74,5 @@ type ManagerProvisioner interface {
 
 	// Object returns a reference to the generic object type, internally
 	// the provisioner will have a type specific version.
-	Object() client.Object
+	Object() unikornv1.ManagableResourceInterface
 }

--- a/pkg/provisioners/managers/cluster/provisioner.go
+++ b/pkg/provisioners/managers/cluster/provisioner.go
@@ -66,7 +66,7 @@ func New() provisioners.ManagerProvisioner {
 // Ensure the ManagerProvisioner interface is implemented.
 var _ provisioners.ManagerProvisioner = &Provisioner{}
 
-func (p *Provisioner) Object() client.Object {
+func (p *Provisioner) Object() unikornv1.ManagableResourceInterface {
 	return &p.cluster
 }
 

--- a/pkg/provisioners/managers/controlplane/provisioner.go
+++ b/pkg/provisioners/managers/controlplane/provisioner.go
@@ -76,7 +76,7 @@ func New() provisioners.ManagerProvisioner {
 // Ensure the ManagerProvisioner interface is implemented.
 var _ provisioners.ManagerProvisioner = &Provisioner{}
 
-func (p *Provisioner) Object() client.Object {
+func (p *Provisioner) Object() unikornv1.ManagableResourceInterface {
 	return &p.controlPlane
 }
 

--- a/pkg/provisioners/managers/project/provisioner.go
+++ b/pkg/provisioners/managers/project/provisioner.go
@@ -27,8 +27,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
@@ -51,7 +49,7 @@ func New() provisioners.ManagerProvisioner {
 // Ensure the ManagerProvisioner interface is implemented.
 var _ provisioners.ManagerProvisioner = &Provisioner{}
 
-func (p *Provisioner) Object() client.Object {
+func (p *Provisioner) Object() unikornv1.ManagableResourceInterface {
 	return &p.project
 }
 

--- a/pkg/provisioners/mock/interfaces.go
+++ b/pkg/provisioners/mock/interfaces.go
@@ -12,11 +12,11 @@ import (
 	context "context"
 	reflect "reflect"
 
+	v1alpha1 "github.com/eschercloudai/unikorn/pkg/apis/unikorn/v1alpha1"
 	cd "github.com/eschercloudai/unikorn/pkg/cd"
 	provisioners "github.com/eschercloudai/unikorn/pkg/provisioners"
 	gomock "go.uber.org/mock/gomock"
 	api "k8s.io/client-go/tools/clientcmd/api"
-	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // MockRemoteCluster is a mock of RemoteCluster interface.
@@ -210,10 +210,10 @@ func (mr *MockManagerProvisionerMockRecorder) Deprovision(arg0 any) *gomock.Call
 }
 
 // Object mocks base method.
-func (m *MockManagerProvisioner) Object() client.Object {
+func (m *MockManagerProvisioner) Object() v1alpha1.ManagableResourceInterface {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Object")
-	ret0, _ := ret[0].(client.Object)
+	ret0, _ := ret[0].(v1alpha1.ManagableResourceInterface)
 	return ret0
 }
 

--- a/pkg/server/handler/cluster/conversion.go
+++ b/pkg/server/handler/cluster/conversion.go
@@ -170,7 +170,7 @@ func convertStatus(in *unikornv1.KubernetesCluster) *generated.KubernetesResourc
 		out.DeletionTime = &in.DeletionTimestamp.Time
 	}
 
-	condition, err := in.LookupCondition(unikornv1.ConditionAvailable)
+	condition, err := in.StatusConditionRead(unikornv1.ConditionAvailable)
 	if err == nil {
 		out.Status = string(condition.Reason)
 	}

--- a/pkg/server/handler/controlplane/client.go
+++ b/pkg/server/handler/controlplane/client.go
@@ -219,7 +219,7 @@ func (c *Client) convert(ctx context.Context, in *unikornv1.ControlPlane) (*gene
 		out.Status.DeletionTime = &in.DeletionTimestamp.Time
 	}
 
-	if condition, err := in.LookupCondition(unikornv1.ConditionAvailable); err == nil {
+	if condition, err := in.StatusConditionRead(unikornv1.ConditionAvailable); err == nil {
 		out.Status.Status = string(condition.Reason)
 	}
 


### PR DESCRIPTION
When scary things are a happening, we can only test so much, so allow resources to be ignored when a controller restarts etc, so we can guinea pig/canary things.  AKA thrown them under the bus without affecting other workloads and giving us a path to recovery.