### PR TITLE
Add Application Tags

### DIFF
--- a/charts/unikorn/crds/unikorn.eschercloud.ai_helmapplications.yaml
+++ b/charts/unikorn/crds/unikorn.eschercloud.ai_helmapplications.yaml
@@ -126,6 +126,13 @@ spec:
                   size limit. We'd like to have this on by default, but mutating admission
                   webhooks and controllers modifying the spec mess this up.
                 type: boolean
+              tags:
+                description: Tags allows an application to be given a free-form set
+                  of labels that can provide grouping, filtering or other contexts.  For
+                  example "networking", "monitoring", "database" etc.
+                items:
+                  type: string
+                type: array
               version:
                 description: Version is the chart version, or a branch when a path
                   is provided.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+ignore:
+- 'generated'
+- 'pkg/server/generated'
+- '**/zz_generated.deepcopy.go'

--- a/pkg/apis/unikorn/v1alpha1/types.go
+++ b/pkg/apis/unikorn/v1alpha1/types.go
@@ -587,6 +587,10 @@ type HelmApplicationSpec struct {
 	// Icon is a base64 encoded icon for the application.
 	// TODO: remove optional once upgrade is complete.
 	Icon []byte `json:"icon,omitempty"`
+	// Tags allows an application to be given a free-form set of labels
+	// that can provide grouping, filtering or other contexts.  For
+	// example "networking", "monitoring", "database" etc.
+	Tags []string `json:"tags,omitempty"`
 	// Exported defines whether the application should be exported to
 	// the user visiable application manager.
 	Exported *bool `json:"exported,omitempty"`

--- a/pkg/apis/unikorn/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/unikorn/v1alpha1/zz_generated.deepcopy.go
@@ -529,6 +529,11 @@ func (in *HelmApplicationSpec) DeepCopyInto(out *HelmApplicationSpec) {
 		*out = make([]byte, len(*in))
 		copy(*out, *in)
 	}
+	if in.Tags != nil {
+		in, out := &in.Tags, &out.Tags
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Exported != nil {
 		in, out := &in.Exported, &out.Exported
 		*out = new(bool)


### PR DESCRIPTION
Had a bit of an epiphany, most things you see allow applications, be they images, containers etc. to have a set of tags attached to them.  At the most basic level this allows grouping of applications to make finding what you desire easier e.g. monitoring, logging, ad inifitum. But you _could_ also look at it another way, rather than filtering out the cruft, you could use/abuse it to prevent cruft from being shown in the first place...